### PR TITLE
[FFM-5355] changed prereq matches from value to identifier

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -497,7 +497,7 @@ class Evaluator < Evaluation
 
         valid_pre_req_variations.each do |element|
 
-          if element.include?(pre_req_evaluated_variation.value)
+          if element.include?(pre_req_evaluated_variation.identifier)
 
             none_match = false
             break

--- a/scripts/openapi.sh
+++ b/scripts/openapi.sh
@@ -43,8 +43,8 @@ if which openapi-generator-cli; then
     fi
   fi
 
-  if  gem install rspec-expectations -v 3.11.0 && \
-      gem install rspec-mocks -v 3.11.0 && \
+  if  gem install rspec-expectations -v 3.12.0 && \
+      gem install rspec-mocks -v 3.12.0 && \
       gem install rake -v 13.0 && \
       gem install minitest -v 5.15.0 && \
       gem install standard -v 1.11.0 && \

--- a/test/ff/ruby/server/sdk/evaluator_tester.rb
+++ b/test/ff/ruby/server/sdk/evaluator_tester.rb
@@ -66,23 +66,45 @@ class EvaluatorTester < Minitest::Test
       end
     end
 
-    data["expected"].each do |key, value|
+    if data["tests"] != nil
+      data["tests"].each do |test|
 
-      puts "Expected: " + key.to_s + " -> " + value.to_s
+        key = test["target"].nil? ? "_no_target" : test["target"]
+        value = test["expected"]
 
-      expected = data["expected"][key]
+        puts "Expected: " + key.to_s + " -> " + value.to_s
 
-      result = EvaluatorTestResult.new(
+        result = EvaluatorTestResult.new(
 
-        data["test_file"],
-        key,
-        expected,
-        data
-      )
+          data["test_file"],
+          key,
+          value,
+          data
+        )
 
-      refute_nil result
+        refute_nil result
 
-      @results.push(result)
+        @results.push(result)
+      end
+    else
+      data["expected"].each do |key, value|
+
+        puts "Expected: " + key.to_s + " -> " + value.to_s
+
+        expected = data["expected"][key]
+
+        result = EvaluatorTestResult.new(
+
+          data["test_file"],
+          key,
+          expected,
+          data
+        )
+
+        refute_nil result
+
+        @results.push(result)
+      end
     end
 
     assert !@results.empty?


### PR DESCRIPTION
WHAT

Evaluation checks for Pre-Req flags were incorrectly implemented in some Server SDKs, as they were checking for value instead of identifier this was uncaught previously because the test cases used boolean flags which had the same string for identifier and value.

FIX
Updates the PreReq check to check against a feature's `identifier` instead of `value`.

TEST
The test cases were updated to properly test with a flag that has identifier that isn't equal to value. The tests on this SDK were updated to use the new test cases.