### PR TITLE
[FFM-5354] Fixes compatibility with Ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.0.3]
+
+- [FFM-4058] Fixes bug in storing target segments
+- [FFM-4755] Fixes multi-variate number variation to return floats instead of int
+- [FFM-5355] Fixes bug in pre-requisite evaluation
+- [FFM-5354] Fixes compatibility with Ruby-2.6
+
 # [1.0.2]
 
 - Runtime and development dependencies specified.

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "minitest", "~> 5.0"
 gem "standard", "~> 1.3"
 
 # Caching support:
-gem "pp"
 gem "rufus-scheduler"
 gem "libcache"
 gem "jwt"

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "minitest", "~> 5.0"
   spec.add_dependency "standard", "~> 1.3"
 
-  spec.add_dependency "pp", "0.3.0"
   spec.add_dependency "rufus-scheduler", "3.8.1"
   spec.add_dependency "libcache", "0.4.2"
   spec.add_dependency "jwt", "2.3.0"

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.0.2"
+        VERSION = "1.0.3"
       end
     end
   end

--- a/scripts/openapi.sh
+++ b/scripts/openapi.sh
@@ -48,7 +48,6 @@ if which openapi-generator-cli; then
       gem install rake -v 13.0 && \
       gem install minitest -v 5.15.0 && \
       gem install standard -v 1.11.0 && \
-      gem install pp -v 0.3.0 && \
       gem install libcache -v 0.4.2 && \
       gem install rufus-scheduler -v 3.8.1 && \
       gem install jwt -v 2.3.0 && \

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.0.2"
+export ff_ruby_sdk_version="1.0.3"


### PR DESCRIPTION
WHAT:
This SDK claims compatibility with Ruby 2.6 on Rubygems, but was not able to be built on Ruby 2.6.

FIX:
Removed the unneeded `pp` dependency that prevented the gem from installing on Ruby 2.6.