### PR TITLE
[FFM-5478]: Ruby SDK failed to cache some flags due to encoding

### DIFF
--- a/lib/ff/ruby/server/sdk/api/polling_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/polling_processor.rb
@@ -68,7 +68,7 @@ class PollingProcessor < Closeable
 
         if s != nil
 
-          @repository.set_flag(s.identifier, s)
+          @repository.set_segment(s.identifier, s)
           segments.push(s)
         end
       }

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.0.3"
+        VERSION = "1.0.4"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.0.3"
+export ff_ruby_sdk_version="1.0.4"

--- a/test/ff/ruby/server/sdk/evaluator_integration_test.rb
+++ b/test/ff/ruby/server/sdk/evaluator_integration_test.rb
@@ -4,25 +4,33 @@ require_relative "evaluator_tester"
 
 class EvaluatorIntegrationTest < Minitest::Test
 
-  def execute
+  $tester
+  $test_data = []
 
-    @tester = EvaluatorTester.new("Evaluator_Tester")
-    prepare_test_data
+  def initialize(name)
+    super(name)
+    $tester = EvaluatorTester.new("Evaluator_Tester")
+    load_test_fixtures
+  end
+
+  def execute
 
     msg = "The evaluator integration test: "
 
     puts msg + "START"
 
-    refute_nil @tester
-    refute_nil @test_data
+    refute_nil $tester
+    refute_nil $test_data
 
-    @test_data.each do |data|
 
-      unless @tester.process(data)
-
-        puts msg + "Failed: " + data["test_file"].to_s
-
-        return false
+    describe "ff-test-grid" do
+      $test_data.each do |data|
+        it "#{data["filename"]}" do
+          unless $tester.process(data)
+            puts msg + "Failed: " + data["test_file"].to_s
+            return false
+          end
+        end
       end
     end
 
@@ -32,17 +40,20 @@ class EvaluatorIntegrationTest < Minitest::Test
 
   private
 
-  def prepare_test_data
+  def load_test_fixtures
 
-    @tests_location = Dir.pwd + "/test/cases/tests"
-
-    @files = Dir.children(@tests_location)
+    @tests_location = Dir.pwd + "/test/cases/tests/"
+    
+    @files = []
+    Dir.glob(@tests_location + "**/*") do |file|
+      if file.end_with?(".json")
+        @files.append(file.delete_prefix(@tests_location))
+      end
+    end
 
     refute_nil @files
 
     assert !@files.empty?
-
-    @test_data = []
 
     @files.each do |file|
 
@@ -57,157 +68,18 @@ class EvaluatorIntegrationTest < Minitest::Test
       if the_file
 
         data = File.read(the_file.path)
-
         refute_nil data
-
         assert !data.empty?
-
         models = JSON.parse(data)
-
         refute_nil models
 
-        models["flags"] = [models["flag"]] if models["flags"].to_a.empty?
-
-        models["flags"].each do |flag_data|
-          model = {}
-          model["flag"] = flag_data
-          model["test_file"] = file
-          model["tests"] = models["tests"] unless models["tests"].nil?
-          model["expected"] = models["expected"] unless models["expected"].nil?
-
-          feature = (model["flag"]["feature"].to_s + file).gsub("_", "").gsub(".", "").downcase
-
-          model["flag"]["feature"] = feature
-
-          flag_hash = model["flag"]
-
-          refute_nil flag_hash
-
-          flag_hash["default_serve"] = OpenapiClient::Serve.new(flag_hash["defaultServe"])
-          flag_hash.delete("defaultServe")
-
-          dist = flag_hash["default_serve"].distribution
-
-          if dist != nil
-
-            flag_hash["default_serve"].distribution = OpenapiClient::Distribution.new(dist)
-          end
-
-          flag_hash["off_variation"] = flag_hash["offVariation"]
-          flag_hash.delete("offVariation")
-
-          flag_hash["variation_to_target_map"] = flag_hash["variationToTargetMap"]
-          flag_hash.delete("variationToTargetMap")
-
-          flag_hash["state"] = OpenapiClient::FeatureState.build_from_hash(flag_hash["state"])
-
-          variations = []
-
-          flag_hash["variations"].each do |v|
-
-            variation = OpenapiClient::Variation.new(v)
-
-            refute_nil variation
-
-            variations.push(variation)
-
-            assert !variations.empty?
-          end
-
-          flag_hash["variations"] = variations
-
-          rules = []
-
-          flag_hash["rules"].each do |v|
-
-            refute_nil v
-
-            v["rule_id"] = v["ruleId"]
-            v.delete("ruleId")
-
-            clauses = []
-
-            if v["clauses"] != nil
-
-              v["clauses"].each do |c|
-
-                clause = OpenapiClient::Clause.new(c)
-
-                refute_nil clause
-
-                clauses.push(clause)
-
-                assert !clauses.empty?
-              end
-            end
-
-            v["clauses"] = clauses
-
-            v["serve"] = OpenapiClient::Serve.new(v["serve"])
-
-            rule = OpenapiClient::ServingRule.new(v)
-
-            refute_nil rule
-
-            rules.push(rule)
-
-            assert !rules.empty?
-          end
-
-          flag_hash["rules"] = rules
-
-          prerequisites = []
-
-          flag_hash["prerequisites"].each do |v|
-
-            prerequisite = OpenapiClient::Prerequisite.new(v)
-
-            refute_nil prerequisite
-
-            prerequisites.push(prerequisite)
-
-            assert !prerequisites.empty?
-          end
-
-          flag_hash["prerequisites"] = prerequisites
-
-          variation_to_target_map = []
-
-          if flag_hash["variation_to_target_map"] != nil
-
-            flag_hash["variation_to_target_map"].each do |v|
-
-              refute_nil v
-
-              v["target_segments"] = v["targetSegments"]
-              v.delete("targetSegments")
-
-              map = OpenapiClient::VariationMap.new(v)
-
-              refute_nil map
-
-              variation_to_target_map.push(map)
-
-              assert !variation_to_target_map.empty?
-            end
-          end
-
-          flag_hash["variation_to_target_map"] = variation_to_target_map
-
-          flag = OpenapiClient::FeatureConfig.new(flag_hash)
-
-          refute_nil flag
-
-          model["flag"] = flag
-
-          @test_data.push(model)
-
-          assert !@test_data.empty?
-        end
+        models["filename"] = file.to_s
+        $test_data.push(models)
+        assert !$test_data.empty?
       else
-
         puts "Not able to access the file: " + file.to_s
       end
     end
+
   end
 end

--- a/test/ff/ruby/server/sdk/evaluator_test_result.rb
+++ b/test/ff/ruby/server/sdk/evaluator_test_result.rb
@@ -5,12 +5,14 @@ class EvaluatorTestResult
   def initialize(
 
     file,
+    flag,
     target_identifier,
     value,
     use_case
   )
 
     @file = file
+    @flag = flag
     @value = value
     @use_case = use_case
     @target_identifier = target_identifier

--- a/test/ff/ruby/server/sdk/sdk_test.rb
+++ b/test/ff/ruby/server/sdk/sdk_test.rb
@@ -335,11 +335,9 @@ class Ff::Ruby::Server::SdkTest < Minitest::Test
     end
   end
 
-  def test_evaluator
-
+  describe "evaluation tests" do
     integration_test = EvaluatorIntegrationTest.new("Main_Evaluator_Integration_Test")
-
-    assert integration_test.execute
+    integration_test.execute
   end
 
   def test_sized_queue


### PR DESCRIPTION
Remove the file cache as it is not required and caused bugs. Ensure the segments are stored using set_segment instead of set_flag on startup Add the latest evaluation tests

The Ruby SDK was failing to store some flags in its cache on startup, this meant the SDK would not function as expected. This only seemed to be a problem for the file cache, rather than in mem
cache.   The file cache could only handle UTF-8 data.

There was also a bug during startup where set_flag was being called in place of set_segment, which meant no group data was stored in the cache.

The evaluation tests were included to help test and verify the above fixes.