### PR TITLE
[FFM-6362] - Ruby FF SDK is not waiting initialization when using "wait_for_initialization" method.

### DIFF
--- a/example/getting_started/getting_started.rb
+++ b/example/getting_started/getting_started.rb
@@ -21,7 +21,10 @@ logger.info "Harness Ruby SDK Getting Started"
 client = CfClient.instance
 
 client.init(apiKey, ConfigBuilder.new.logger(logger).build)
+
+logger.info "----- initialization started ----- "
 client.wait_for_initialization
+logger.info "----- initialization done ----- "
 
 # Create a target (different targets can get different results based on rules.  This include a custom attribute 'location')
 target = Target.new("RubySDK", identifier="rubysdk", attributes={"location": "emea"})

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -223,6 +223,8 @@ class InnerClient < ClientCallback
       return
     end
 
+    @config.logger.info "All processors now ready"
+
     @initialized = true
 
     # TODO: notify - Reactivity support
@@ -262,7 +264,8 @@ class InnerClient < ClientCallback
     @repository = StorageRepository.new(@config.cache, @repository_callback, @config.store, @config.logger)
 
     @metrics_callback = InnerClientMetricsCallback.new(self, @config.logger)
-    @metrics_processor = MetricsProcessor.new(@connector, @config, @metrics_callback)
+    @metrics_processor = MetricsProcessor.new
+    @metrics_processor.init(@connector, @config, @metrics_callback)
 
     @evaluator = Evaluator.new(@repository, logger = @config.logger)
     @evaluator_callback = InnerClientFlagEvaluateCallback.new(@metrics_processor, logger = @config.logger)
@@ -275,8 +278,8 @@ class InnerClient < ClientCallback
       logger = @config.logger
     )
 
-    @poll_processor = PollingProcessor.new(
-
+    @poll_processor = PollingProcessor.new
+    @poll_processor.init(
       connector = @connector,
       repository = @repository,
       poll_interval_in_sec = @config.poll_interval_in_seconds,
@@ -291,7 +294,8 @@ class InnerClient < ClientCallback
       logger = @config.logger
     )
 
-    @update_processor = UpdateProcessor.new(
+    @update_processor = UpdateProcessor.new
+    @update_processor.init(
 
       connector = @connector,
       repository = @repository,

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -9,7 +9,7 @@ require_relative "../api/summary_metrics"
 
 class MetricsProcessor < Closeable
 
-  def initialize(
+  def init(
 
     connector,
     config,

--- a/lib/ff/ruby/server/sdk/api/polling_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/polling_processor.rb
@@ -2,7 +2,7 @@ require_relative "../common/closeable"
 
 class PollingProcessor < Closeable
 
-  def initialize(
+  def init(
 
     connector,
     repository,

--- a/lib/ff/ruby/server/sdk/api/update_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/update_processor.rb
@@ -4,7 +4,7 @@ require_relative "../common/closeable"
 
 class UpdateProcessor < Closeable
 
-  def initialize(
+  def init(
 
     connector,
     repository,

--- a/test/ff/ruby/server/sdk/sdk_test.rb
+++ b/test/ff/ruby/server/sdk/sdk_test.rb
@@ -288,7 +288,8 @@ class Ff::Ruby::Server::SdkTest < Minitest::Test
 
     refute_nil callback
 
-    processor = PollingProcessor.new(
+    processor = PollingProcessor.new
+    processor.init(
 
       connector,
       repository,


### PR DESCRIPTION
[FFM-6362] - Ruby FF SDK is not waiting initialization when using "wait_for_initialization" method.

Why
wait_for_initialization does not wait and returns too quickly, allowing caller to evaluate flags before they're ready

What
The update processor is taking a callback which is attempting to compare vairiables which haven't been set yet, causing the code to exit early. Separate the constructors and add new init methods so we are not comparing 'nil'

Testing
Tested getting started in RubyMine

[FFM-6362]: https://harness.atlassian.net/browse/FFM-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ