### PR TITLE
FFM-6965 - Ruby SDK - analytics_enabled=false doesn't fully turn off …

### DIFF
--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -268,7 +268,10 @@ class InnerClient < ClientCallback
     @metrics_processor.init(@connector, @config, @metrics_callback)
 
     @evaluator = Evaluator.new(@repository, logger = @config.logger)
-    @evaluator_callback = InnerClientFlagEvaluateCallback.new(@metrics_processor, logger = @config.logger)
+
+    if @config.analytics_enabled
+      @evaluator_callback = InnerClientFlagEvaluateCallback.new(@metrics_processor, logger = @config.logger)
+    end
 
     @auth_service = AuthService.new(
 


### PR DESCRIPTION
FFM-6965 - Ruby SDK - analytics_enabled=false doesn't fully turn off metrics

What
When analytics_enabled is false we still write entries to the metrics queue, this fix will set the callback to nil to stop the queue from being written to.

Why
When the metrics processor is disabled, there's nothing consuming from the queue and will eventually fill up and lead to a memory leak

Testing
Tested manually