### PR TITLE
FFM-7005 - TLS support custom CAs - remove sse-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "moneta"
 
 # SSE support:
 gem "rest-client"
-gem "sse-client"
 
 # Concurrency support:
 gem "concurrent-ruby", require: "concurrent"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ client.close
 
 ```bash
 # Install the deps
-gem install ff-ruby-server-sdk typhoeus openapi_client
+gem install ff-ruby-server-sdk typhoeus
 
 # Set your API Key
 export FF_API_KEY=<your key here>
@@ -96,7 +96,7 @@ use docker to quickly get started
 
 ```bash
 # Install the package
-docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY ruby:2.7-buster gem install --install-dir ./gems ff-ruby-server-sdk typhoeus openapi_client
+docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY ruby:2.7-buster gem install --install-dir ./gems ff-ruby-server-sdk typhoeus
 
 # Run the script
 docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY -e GEM_HOME=/app/gems ruby:2.7-buster ruby ./example/getting_started/getting_started.rb

--- a/buildInContainer.sh
+++ b/buildInContainer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ruby -v
+apt-get update
+apt-get install -y npm
+apt-get install -y maven
+apt-get install -y jq
+mvn --version
+npm install @openapitools/openapi-generator-cli -g
+npm install @openapitools/openapi-generator-cli -D
+gem install minitest-junit
+sh scripts/install.sh
+gem env
+gem install ff-ruby-server-sdk typhoeus
+ruby test/ff/ruby/server/sdk/sdk_test.rb --junit

--- a/example/getting_started/getting_started.rb
+++ b/example/getting_started/getting_started.rb
@@ -32,7 +32,7 @@ target = Target.new("RubySDK", identifier="rubysdk", attributes={"location": "em
 # Loop forever reporting the state of the flag
 loop do
   result = client.bool_variation(flagName, target, false)
-  logger.info "Flag variation:  #{result}"
+  logger.info "Flag #{flagName} is set to:  #{result}"
   sleep 10
 end
 

--- a/example/tls_example/tls_example.rb
+++ b/example/tls_example/tls_example.rb
@@ -18,9 +18,10 @@ flagName = ENV['FF_FLAG_NAME'] || 'harnessappdemodarkmode'
 logger.info "Harness Ruby SDK Getting Started"
 
 =begin
- For ff servers with a custom or private CAs, you can use 'tls_ca_cert' to pass in the CAs. Typhoeus HTTP client uses
- libcurl underneath, when developing you should enable debugging(true) to get more detailed error diagnostics logged,
- which aren't reported through OpenAPI. Common errors include:
+ For ff servers with a custom or private CAs, you can use 'tls_ca_cert' to pass in the CA bundle in ASCII PEM format.
+ You should also include any intermediate CAs so the full trust chain can be resolved. Typhoeus HTTP client uses libcurl
+ underneath, when developing you should enable debugging(true) to get more detailed error diagnostics logged, which
+ aren't reported through OpenAPI. Common errors include:
 
  SSL peer certificate or SSH remote key was not OK - you have an invalid or missing CA for the server you're trying
                                                      to connect to. It can also mean the server hostname and request
@@ -33,6 +34,10 @@ logger.info "Harness Ruby SDK Getting Started"
 The example below assumes you have an ff-server (or proxy) configured with TLS for a server hosted on
 'ffserver:8000' where the web server's cert has a SANs with DNS entry 'ffserver'. CA.crt tells the SDK you trust this
 server.
+
+Typhoeus/libcurl by default has its default CA bundle stored at /etc/ssl/cert.pem. You can append your CA here if
+you choose not to use 'tls_ca_cert'.
+
 =end
 
 

--- a/example/tls_example/tls_example.rb
+++ b/example/tls_example/tls_example.rb
@@ -43,7 +43,7 @@ you choose not to use 'tls_ca_cert'.
 
 client = CfClient.instance
 client.init(apiKey, ConfigBuilder.new.logger(logger)
-                                 .event_url("https://ffserver:8000/api/1.0")
+                                 .event_url("https://ffserver:8001/api/1.0")
                                  .config_url("https://ffserver:8000/api/1.0")
                                  .tls_ca_cert("/path/to/CA.crt")
                                  .debugging(true)

--- a/example/tls_example/tls_example.rb
+++ b/example/tls_example/tls_example.rb
@@ -15,7 +15,7 @@ apiKey = ENV['FF_API_KEY'] || 'changeme'
 # Flag Name
 flagName = ENV['FF_FLAG_NAME'] || 'harnessappdemodarkmode'
 
-logger.info "Harness Ruby SDK Getting Started"
+logger.info "Harness Ruby SDK TLS example"
 
 =begin
  For ff servers with a custom or private CAs, you can use 'tls_ca_cert' to pass in the CA bundle in ASCII PEM format.

--- a/example/tls_example/tls_example.rb
+++ b/example/tls_example/tls_example.rb
@@ -43,8 +43,8 @@ you choose not to use 'tls_ca_cert'.
 
 client = CfClient.instance
 client.init(apiKey, ConfigBuilder.new.logger(logger)
-                                 .event_url("https://ffserver:8000")
-                                 .config_url("https://ffserver:8000")
+                                 .event_url("https://ffserver:8000/api/1.0")
+                                 .config_url("https://ffserver:8000/api/1.0")
                                  .tls_ca_cert("/path/to/CA.crt")
                                  .debugging(true)
                                  .build)

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "moneta", "1.4.2"
 
   spec.add_dependency "rest-client", "2.1.0"
-  spec.add_dependency "sse-client", "1.1.0"
 
   spec.add_dependency "concurrent-ruby", "1.1.10"
 

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)}) || f.start_with?("ruby_on_rails_example")
     end
   end
 
@@ -52,6 +52,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "1.1.10"
 
   spec.add_dependency "murmurhash3", "0.1.6"
-
-  spec.add_dependency "openapi_client", "~> 1.0.0"
 end

--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -1,5 +1,5 @@
-require "openapi_client"
 
+require_relative "../../generated/lib/openapi_client"
 require_relative "../common/closeable"
 require_relative "inner_client"
 

--- a/lib/ff/ruby/server/sdk/api/config.rb
+++ b/lib/ff/ruby/server/sdk/api/config.rb
@@ -7,7 +7,7 @@ class Config
   attr_accessor :config_url, :event_url, :stream_enabled, :poll_interval_in_seconds, :analytics_enabled,
                 :frequency, :buffer_size, :all_attributes_private, :private_attributes, :connection_timeout,
                 :read_timeout, :write_timeout, :debugging, :metrics_service_acceptable_duration, :cache, :store,
-                :logger
+                :logger, :ssl_ca_cert
 
   # Static:
   class << self
@@ -97,7 +97,7 @@ class Config
 
   def ssl_ca_cert
 
-    nil
+    @ssl_ca_cert
   end
 
   def client_side_validation

--- a/lib/ff/ruby/server/sdk/api/config.rb
+++ b/lib/ff/ruby/server/sdk/api/config.rb
@@ -82,7 +82,7 @@ class Config
 
   def verify_ssl
 
-    nil
+    true
   end
 
   def cert_file

--- a/lib/ff/ruby/server/sdk/api/config_builder.rb
+++ b/lib/ff/ruby/server/sdk/api/config_builder.rb
@@ -83,6 +83,11 @@ class ConfigBuilder
     self
   end
 
+  def tls_ca_cert(cert_file)
+    @config.ssl_ca_cert = cert_file
+    self
+  end
+
   def logger(logger)
 
     @config.logger = logger

--- a/lib/ff/ruby/server/sdk/api/inner_client_updater.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client_updater.rb
@@ -53,7 +53,7 @@ class InnerClientUpdater < Updater
 
   def on_error
 
-    @logger.error "Error occurred"
+    @logger.error "InnerClientUpdater error occurred"
   end
 
   def update(message)

--- a/lib/ff/ruby/server/sdk/connector/events.rb
+++ b/lib/ff/ruby/server/sdk/connector/events.rb
@@ -10,13 +10,14 @@ class Events < Service
     url,
     headers,
     updater,
-    logger = nil
+    config
   )
 
     @url = url
     @headers = headers
     @headers['params'] = {}
     @updater = updater
+    @config = config
 
     if @updater != nil
       unless @updater.kind_of?(Updater)
@@ -24,8 +25,8 @@ class Events < Service
       end
     end
 
-    if logger != nil
-      @logger = logger
+    if @config.logger != nil
+      @logger = @config.logger
     else
       @logger = Logger.new(STDOUT)
     end
@@ -42,7 +43,9 @@ class Events < Service
                                          block_response: proc { |response| response_handler response },
                                          before_execution_proc: nil,
                                          log: false,
-                                         read_timeout: 60)
+                                         read_timeout: 60,
+                                         ssl_ca_file: @config.ssl_ca_cert)
+
 
     rescue => e
       @logger.warn "SSE connection failed: " + e.message

--- a/lib/ff/ruby/server/sdk/connector/events.rb
+++ b/lib/ff/ruby/server/sdk/connector/events.rb
@@ -1,5 +1,5 @@
 require "json"
-require "sse-client"
+require 'restclient'
 
 require_relative './service'
 
@@ -13,106 +13,99 @@ class Events < Service
     logger = nil
   )
 
+    @url = url
+    @headers = headers
+    @headers['params'] = {}
+    @updater = updater
+
     if @updater != nil
-
       unless @updater.kind_of?(Updater)
-
         raise "The 'callback' parameter must be of '" + Updater.to_s + "' data type"
       end
     end
 
-    @updater = updater
-
     if logger != nil
-
       @logger = logger
     else
-
       @logger = Logger.new(STDOUT)
-    end
-
-    @sse = SSE::EventSource.new(
-
-      url = url,
-      query = {},
-      headers = headers
-    )
-
-    @sse.open do
-
-      on_open
-    end
-
-    @sse.error do |error|
-
-      if error != nil
-
-        @logger.error "SSE ERROR: " + error.body
-      end
-
-      on_error
-    end
-
-    @sse.message do |message|
-
-      on_message(message)
-    end
-
-    @sse.on("*") do |message|
-
-      on_message(message)
     end
 
     @updater.on_ready
   end
 
   def start
-
     @logger.info "Starting EventSource service"
+    begin
+      conn = RestClient::Request.execute(method: :get,
+                                         url: @url,
+                                         headers: @headers,
+                                         block_response: proc { |response| response_handler response },
+                                         before_execution_proc: nil,
+                                         log: false,
+                                         read_timeout: 60)
 
-    @sse.start
+    rescue => e
+      @logger.warn "SSE connection failed: " + e.message
+      on_error
+    end
   end
 
   def stop
-
     @logger.info "Stopping EventSource service"
-
     on_closed
   end
 
   def close
-
     stop
   end
 
   def on_open
-
     @logger.info "EventSource connected"
-
     @updater.on_connected
   end
 
   def on_error
-
     @logger.error "EventSource error"
-
     @updater.on_error
-
     stop
   end
 
   def on_closed
-
     @logger.info "EventSource disconnected"
-
     @updater.on_disconnected
   end
 
   def on_message(message)
-
     @logger.debug "EventSource message received " + message.to_s
-
     msg = JSON.parse(message)
     @updater.update(msg)
   end
+
+  private
+
+  def emit_line(line)
+    if line.start_with?("data:")
+      @logger.debug "SSE emit line: " + line
+      on_message line[line.index("{")..-1]
+    end
+  end
+
+  def response_handler(response)
+    on_open
+    case response.code
+    when "200"
+      line = ""
+      response.read_body do |chunk|
+        line << chunk
+        while line.sub!(/^(.*)\n/,"")
+            emit_line $1
+        end
+      end
+      close
+    else
+      @logger.error "SSE ERROR: http_code=%d body=%d" % [response.code, response.body]
+      on_error
+    end
+  end
+
 end

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -147,7 +147,7 @@ class HarnessConnector < Connector
       url,
       headers,
       updater,
-      @config.logger
+      @config
     )
 
     @event_source

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.0.6"
+        VERSION = "1.0.7"
       end
     end
   end

--- a/scripts/openapi.sh
+++ b/scripts/openapi.sh
@@ -57,12 +57,9 @@ if which openapi-generator-cli; then
       gem install concurrent-ruby -v 1.1.10 && \
       gem install murmurhash3 -v 0.1.6 && \
       cd "$dir_path/.." && \
-      openapi-generator-cli generate -i api.yaml -g ruby -o "$generated_path" && \
-      cd "$generated_path" && gem build openapi_client.gemspec && \
-      test -e "openapi_client-1.0.0.gem" && \
-      gem install --dev "openapi_client-1.0.0.gem"; then
+      openapi-generator-cli generate -i api.yaml -g ruby -o "$generated_path"; then
 
-      echo "Generated API has been installed with success: $generated_path"
+      echo "API has been generated with success: $generated_path"
   else
 
       echo "ERROR: 'openapi-generator-cli' is not installed [1] 😬"

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.0.6"
+export ff_ruby_sdk_version="1.0.7"


### PR DESCRIPTION
FFM-7005 - TLS support custom CAs - remove sse-client

What
Add support for private/custom CA certs which can be passed in by the caller as a list of X.509s. Remove sse-client module since it prevents access to the underlying TLS APIs of restclient module

Why
Allow SDK to connect to non-SaaS hosted environments.

Testing
Manually