### PR TITLE
FFM-6701 - Ruby SDK 1.0.6 not working with Testgrid image

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ client.close
 
 ```bash
 # Install the deps
-gem install ff-ruby-server-sdk typhoeus openapi_client
+gem install ff-ruby-server-sdk typhoeus
 
 # Set your API Key
 export FF_API_KEY=<your key here>
@@ -96,7 +96,7 @@ use docker to quickly get started
 
 ```bash
 # Install the package
-docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY ruby:2.7-buster gem install --install-dir ./gems ff-ruby-server-sdk typhoeus openapi_client
+docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY ruby:2.7-buster gem install --install-dir ./gems ff-ruby-server-sdk typhoeus
 
 # Run the script
 docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY -e GEM_HOME=/app/gems ruby:2.7-buster ruby ./example/getting_started/getting_started.rb

--- a/buildInContainer.sh
+++ b/buildInContainer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ruby -v
+apt-get update
+apt-get install -y npm
+apt-get install -y maven
+apt-get install -y jq
+mvn --version
+npm install @openapitools/openapi-generator-cli -g
+npm install @openapitools/openapi-generator-cli -D
+gem install minitest-junit
+sh scripts/install.sh
+gem env
+gem install ff-ruby-server-sdk typhoeus
+ruby test/ff/ruby/server/sdk/sdk_test.rb --junit

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)}) || f.start_with?("ruby_on_rails_example")
     end
   end
 
@@ -53,6 +53,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "1.1.10"
 
   spec.add_dependency "murmurhash3", "0.1.6"
-
-  spec.add_dependency "openapi_client", "~> 1.0.0"
 end

--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -1,5 +1,5 @@
-require "openapi_client"
 
+require_relative "../../generated/lib/openapi_client"
 require_relative "../common/closeable"
 require_relative "inner_client"
 

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.0.6"
+        VERSION = "1.0.7"
       end
     end
   end

--- a/scripts/openapi.sh
+++ b/scripts/openapi.sh
@@ -57,12 +57,9 @@ if which openapi-generator-cli; then
       gem install concurrent-ruby -v 1.1.10 && \
       gem install murmurhash3 -v 0.1.6 && \
       cd "$dir_path/.." && \
-      openapi-generator-cli generate -i api.yaml -g ruby -o "$generated_path" && \
-      cd "$generated_path" && gem build openapi_client.gemspec && \
-      test -e "openapi_client-1.0.0.gem" && \
-      gem install --dev "openapi_client-1.0.0.gem"; then
+      openapi-generator-cli generate -i api.yaml -g ruby -o "$generated_path"; then
 
-      echo "Generated API has been installed with success: $generated_path"
+      echo "API has been generated with success: $generated_path"
   else
 
       echo "ERROR: 'openapi-generator-cli' is not installed [1] 😬"

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.0.6"
+export ff_ruby_sdk_version="1.0.7"


### PR DESCRIPTION
FFM-6701 - Ruby SDK 1.0.6 not working with Testgrid image

What
Remove all references to openapi_client-1.0.0, don't build it anymore as a gem when scripts/install.sh is called. Instead the generated API sources should be baked into the main SDK gem directly to simplify deployment.

Why
Ruby test grid image is failing to come up because it's trying to pull a conflicting gem called openapi_client-1.0.0 of an example project that has already been published elsewhere. Looks like openapi_client-1.0.0 was only ever meant to be a locally built gem.

Testing
Compiled and built Ruby test grid image to ensure it starts correctly with no errors.