### PR TITLE
FFM-7285 - Remove Metrics queue and implement Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 .idea
 *.gem
 Gemfile.lock
-generated
+lib/ff/ruby/server/generated
 cache
 moneta
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,19 @@ gem "moneta"
 gem "rest-client"
 
 # Concurrency support:
-gem "concurrent-ruby", require: "concurrent"
+gem "concurrent-ruby", "1.1.10", require: "concurrent"
 
 # Evaluator dependencies:
 gem "murmurhash3"
+
+gem "typhoeus"
+
+group :test do
+  gem 'simplecov', '~> 0.21.2'
+end
+
+group :development, :test do
+  gem 'rake', '~> 13.0.1'
+  gem 'pry-byebug'
+  gem 'rubocop', '~> 0.66.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,3 @@ group :test do
   gem 'simplecov', '~> 0.21.2'
 end
 
-group :development, :test do
-  gem 'rake', '~> 13.0.1'
-  gem 'pry-byebug'
-  gem 'rubocop', '~> 0.66.0'
-end

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -52,4 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "1.1.10"
 
   spec.add_dependency "murmurhash3", "0.1.6"
+
+  spec.add_dependency "typhoeus", '~> 1.0', '>= 1.0.1'
 end

--- a/lib/ff/ruby/server/sdk/api/config.rb
+++ b/lib/ff/ruby/server/sdk/api/config.rb
@@ -35,7 +35,7 @@ class Config
 
     @frequency = @@min_frequency
 
-    @buffer_size = 1024
+    @buffer_size = 2048
 
     @all_attributes_private = false
 

--- a/lib/ff/ruby/server/sdk/api/inner_client_flag_evaluate_callback.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client_flag_evaluate_callback.rb
@@ -25,6 +25,6 @@ class InnerClientFlagEvaluateCallback < FlagEvaluateCallback
 
     @logger.debug "Processing evaluation: " + feature_config.feature.to_s + ", " + target.identifier.to_s
 
-    @metrics_processor.push_to_queue(target, feature_config, variation)
+    @metrics_processor.register_evaluation(target, feature_config, variation)
   end
 end

--- a/lib/ff/ruby/server/sdk/api/metrics_event.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_event.rb
@@ -2,15 +2,27 @@ class MetricsEvent
 
   attr_accessor :feature_config, :target, :variation
 
-  def initialize(
-
-    feature_config,
-    target,
-    variation
-  )
+  def initialize(feature_config, target, variation)
 
     @target = target
     @variation = variation
     @feature_config = feature_config
+    freeze
   end
+
+  def ==(other)
+    eql?(other)
+  end
+
+  def eql?(other)
+    feature_config.feature == other.feature_config.feature and
+      variation.identifier == other.variation.identifier and
+      target.identifier == other.target.identifier
+  end
+
+  def hash
+    feature_config.feature.hash | variation.identifier.hash | target.identifier.hash
+  end
+
+
 end

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -9,25 +9,47 @@ require_relative "../api/summary_metrics"
 
 class MetricsProcessor < Closeable
 
-  def init(
+  class FrequencyMap < Concurrent::Map
+    def initialize(options = nil, &block)
+      super
+    end
 
-    connector,
-    config,
-    callback
-  )
+    def increment(key)
+      compute(key) do |old_value|
+        if old_value == nil; 1 else old_value + 1 end
+      end
+    end
+
+    def get(key)
+      self[key]
+    end
+
+    def drain_to_map
+      result = {}
+      each_key do |key|
+        result[key] = 0
+      end
+      result.each_key do |key|
+        value = get_and_set(key, 0)
+        result[key] = value
+        delete_pair(key, 0)
+      end
+      result
+    end
+  end
+
+
+  def init(connector, config, callback)
 
     unless connector.kind_of?(Connector)
-
       raise "The 'connector' must be of '" + Connector.to_s + "' data type"
     end
 
     unless callback.kind_of?(MetricsCallback)
-
       raise "The 'callback' must be of '" + MetricsCallback.to_s + "' data type"
     end
 
     unless config.kind_of?(Config)
-
       raise "The 'config' must be of '" + Config.to_s + "' data type"
     end
 
@@ -51,200 +73,83 @@ class MetricsProcessor < Closeable
     @feature_name_attribute = "featureName"
     @variation_identifier_attribute = "variationIdentifier"
 
-    @queue = SizedQueue.new(@config.buffer_size)
-    @executor = Concurrent::FixedThreadPool.new(100)
+    @executor = Concurrent::FixedThreadPool.new(10)
+
+    @frequency_map = FrequencyMap.new
 
     @callback.on_metrics_ready
   end
 
   def start
-
     @config.logger.info "Starting metrics processor with request interval: " + @config.frequency.to_s
     start_async
   end
 
   def stop
-
     @config.logger.info "Stopping metrics processor"
     stop_async
   end
 
   def close
-
     stop
     @config.logger.info "Closing metrics processor"
   end
 
-  def push_to_queue(
+  def register_evaluation(target, feature_config, variation)
 
-    target,
-    feature_config,
-    variation
-  )
-
-    @executor.post do
-
-      @config.logger.debug "Pushing to the metrics queue: START"
-
-      event = MetricsEvent.new(feature_config, target, variation)
-      @queue.push(event)
-
-      @config.logger.debug "Pushing to the metrics queue: END, queue size: " + @queue.size.to_s
-
-    end
-  end
-
-  def send_data_and_reset_cache(data)
-
-    @config.logger.debug "Reading from queue and building cache"
-
-    @jar_version = get_version
-
-    unless data.empty?
-
-      map = {}
-
-      data.each do |event|
-
-        new_value = 1
-        current = map[event]
-
-        if current != nil
-
-          new_value = current + 1
-        end
-
-        map[event] = new_value
-      end
-
-      metrics = prepare_summary_metrics_body(map)
-
-      if !metrics.metrics_data.empty? && !metrics.target_data.empty?
-
-        start_time = (Time.now.to_f * 1000).to_i
-
-        @connector.post_metrics(metrics)
-
-        end_time = (Time.now.to_f * 1000).to_i
-
-        if end_time - start_time > @config.metrics_service_acceptable_duration
-
-          @config.logger.debug "Metrics service API duration=[" + (end_time - start_time).to_s + "]"
-        end
-      end
-
-      @global_target_set.merge(@staging_target_set)
-      @staging_target_set.clear
-    end
-  end
-
-  protected
-
-  def run_one_iteration
-
-    @config.logger.debug "Async metrics iteration: " + @thread.to_s
-
-    data = []
-
-    until @queue.empty?
-
-      item = @queue.pop
-      data.push(item)
-    end
-
-    send_data_and_reset_cache(data)
-  end
-
-  def prepare_summary_metrics_body(data)
-
-    summary_metrics_data = {}
-    metrics = OpenapiClient::Metrics.new({ :target_data => [], :metrics_data => [] })
-
-    add_target_data(
-
-      metrics,
-      Target.new(
-
-        name = @global_target_name,
-        identifier = @global_target
-      )
-    )
-
-    data.each do |key, value|
-
-      target = key.target
-
-      add_target_data(metrics, target)
-
-      summary_metrics = prepare_summary_metrics_key(key)
-
-      summary_metrics_data[summary_metrics] = value
-    end
-
-    summary_metrics_data.each do |key, value|
-
-      metrics_data = OpenapiClient::MetricsData.new({ :attributes => [] })
-      metrics_data.timestamp = (Time.now.to_f * 1000).to_i
-      metrics_data.count = value
-      metrics_data.metrics_type = "FFMETRICS"
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @feature_name_attribute, :value => key.feature_name }))
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @variation_identifier_attribute, :value => key.variation_identifier }))
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @target_attribute, :value => @global_target }))
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_type, :value => @server }))
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_language, :value => "ruby" }))
-      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_version, :value => @jar_version }))
-
-      metrics.metrics_data.push(metrics_data)
-    end
-
-    metrics
-  end
-
-  private
-
-  def start_async
-
-    @config.logger.debug "Async starting: " + self.to_s
-
-    @ready = true
-
-    @thread = Thread.new do
-
-      @config.logger.debug "Async started: " + self.to_s
-
-      while @ready do
-
-        unless @initialized
-
-          @initialized = true
-          @config.logger.info "Metrics processor initialized"
-        end
-
-        sleep(@config.frequency)
-
+    if @frequency_map.size > @config.buffer_size - 1
+      @executor.post do
         run_one_iteration
       end
     end
 
-    @thread.run
+    event = MetricsEvent.new(feature_config, target, variation)
+    @frequency_map.increment event
   end
 
-  def stop_async
+  private
 
-    @queue.clear
-
-    @ready = false
-    @initialized = false
+  def run_one_iteration
+    send_data_and_reset_cache @frequency_map.drain_to_map
   end
 
-  def prepare_summary_metrics_key(key)
+  def send_data_and_reset_cache(map)
+    metrics = prepare_summary_metrics_body(map)
 
-    SummaryMetrics.new(
+    if !metrics.metrics_data.empty? && !metrics.target_data.empty?
+      start_time = (Time.now.to_f * 1000).to_i
+      @connector.post_metrics(metrics)
+      end_time = (Time.now.to_f * 1000).to_i
+      if end_time - start_time > @config.metrics_service_acceptable_duration
+        @config.logger.debug "Metrics service API duration=[" + (end_time - start_time).to_s + "]"
+      end
+    end
 
-      feature_name = key.feature_config.feature,
-      variation_identifier = key.variation.identifier,
-      variation_value = key.variation.value
-    )
+    @global_target_set.merge(@staging_target_set)
+    @staging_target_set.clear
+
+  end
+
+  def prepare_summary_metrics_body(freq_map)
+    metrics = OpenapiClient::Metrics.new({ :target_data => [], :metrics_data => [] })
+    add_target_data(metrics, Target.new(name = @global_target_name, identifier = @global_target))
+    freq_map.each_key do |key|
+      add_target_data(metrics, key.target)
+    end
+    freq_map.each do |key, value|
+      metrics_data = OpenapiClient::MetricsData.new({ :attributes => [] })
+      metrics_data.timestamp = (Time.now.to_f * 1000).to_i
+      metrics_data.count = value
+      metrics_data.metrics_type = "FFMETRICS"
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @feature_name_attribute, :value => key.feature_config.feature }))
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @variation_identifier_attribute, :value => key.variation.identifier }))
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @target_attribute, :value => @global_target }))
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_type, :value => @server }))
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_language, :value => "ruby" }))
+      metrics_data.attributes.push(OpenapiClient::KeyValue.new({ :key => @sdk_version, :value => @jar_version }))
+      metrics.metrics_data.push(metrics_data)
+    end
+    metrics
   end
 
   def add_target_data(metrics, target)
@@ -253,45 +158,57 @@ class MetricsProcessor < Closeable
     private_attributes = target.private_attributes
 
     if !@staging_target_set.include?(target) && !@global_target_set.include?(target) && !target.is_private
-
       @staging_target_set.add(target)
-
       attributes = target.attributes
-
       attributes.each do |k, v|
-
         key_value = OpenapiClient::KeyValue.new
-
         if !private_attributes.empty?
-
           unless private_attributes.include?(k)
-
             key_value = OpenapiClient::KeyValue.new({ :key => k, :value => v.to_s })
           end
         else
-
           key_value = OpenapiClient::KeyValue.new({ :key => k, :value => v.to_s })
         end
-
         target_data.attributes.push(key_value)
       end
-
       target_data.identifier = target.identifier
-
       if target.name == nil || target.name == ""
-
         target_data.name = target.identifier
       else
-
         target_data.name = target.name
       end
-
       metrics.target_data.push(target_data)
     end
   end
 
-  def get_version
+  def start_async
+    @config.logger.debug "Async starting: " + self.to_s
+    @ready = true
+    @thread = Thread.new do
+      @config.logger.debug "Async started: " + self.to_s
+      while @ready do
+        unless @initialized
+          @initialized = true
+          @config.logger.info "Metrics processor initialized"
+        end
+        sleep(@config.frequency)
+        run_one_iteration
+      end
+    end
+    @thread.run
+  end
 
+  def stop_async
+    @ready = false
+    @initialized = false
+  end
+
+  def get_version
     Ff::Ruby::Server::Sdk::VERSION
   end
+
+  def get_frequency_map
+    @frequency_map
+  end
+
 end

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.0.7"
+        VERSION = "1.1.0"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.0.7"
+export ff_ruby_sdk_version="1.1.0"

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -1,0 +1,182 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk"
+require "concurrent/atomics"
+
+class MetricsProcessorTest < Minitest::Test
+
+  class TestCallback < MetricsCallback
+    def initialize
+      @latch = Concurrent::CountDownLatch.new(1)
+    end
+
+    def on_metrics_ready
+      @latch.count_down
+    end
+
+    def on_metrics_error(error)
+      print error
+    end
+
+    def wait_until_ready
+      print "Wait for metrics processor to start"
+      @latch.wait 30
+    end
+  end
+
+  class TestConnector < Connector
+    def initialize
+      @captured_metrics = []
+    end
+
+    def post_metrics(metrics)
+      @captured_metrics.push metrics
+      puts metrics.to_s.gsub "},", "},\n"
+
+      metrics.target_data.each do |target|
+        puts "target: #{target.identifier} #{target.name}"
+        target.attributes do |attr, value|
+          puts "        #{attr}=#{value}"
+        end
+        target.attributes do |attr, value|
+          puts "        #{attr}=#{value}"
+        end
+      end
+
+      metrics.metrics_data.each do |metrics_row|
+        puts "metrics: #{metrics_row.count}"
+        metrics_row.attributes.each do |kv|
+          unless kv.key.start_with?("SDK_")
+            puts "         #{kv.key}=#{kv.value}"
+          end
+        end
+      end
+    end
+
+    def get_flags
+      print "get_flags"
+      []
+    end
+
+    def get_segments
+      print "get_segments"
+      []
+    end
+
+    def get_captured_metrics
+      @captured_metrics
+    end
+  end
+
+  def initialize(name)
+    super
+
+    @target = Target.new "target-name", "target-id"
+
+    @variation1 = OpenapiClient::Variation.new
+    @variation1.identifier = "variation1"
+    @variation1.value = "on"
+    @variation1.name = "Test"
+
+    @variation2 = OpenapiClient::Variation.new
+    @variation2.identifier = "variation2"
+    @variation2.value = "off"
+    @variation2.name = "Test"
+
+    @feature1 = OpenapiClient::FeatureConfig.new
+    @feature1.feature = "feature-name"
+    @feature1.variations = [ @variation1, @variation2 ]
+
+    @feature2 = OpenapiClient::FeatureConfig.new
+    @feature2.feature = "feature-name2"
+    @feature2.variations = [ @variation1, @variation2 ]
+  end
+
+  def test_metrics
+
+    logger = Logger.new(STDOUT)
+    callback = TestCallback.new
+    connector = TestConnector.new
+    config = MiniTest::Mock.new
+    config.expect :kind_of?, true, [Config.class]
+    config.expect :metrics_service_acceptable_duration, 10000
+
+    (1..20).each { |_| config.expect :buffer_size, 10 }
+    (1..20).each { |_| config.expect :logger, logger }
+
+    metrics_processor = MetricsProcessor.new
+    metrics_processor.init connector, config, callback
+
+    callback.wait_until_ready
+
+    (1..3).each { metrics_processor.register_evaluation @target, @feature1, @variation1 }
+    (1..3).each { metrics_processor.register_evaluation @target, @feature1, @variation2 }
+    (1..3).each { metrics_processor.register_evaluation @target, @feature2, @variation1 }
+    (1..3).each { metrics_processor.register_evaluation @target, @feature2, @variation2 }
+
+    freq_map = metrics_processor.send :get_frequency_map
+    assert_equal 4, freq_map.size, "not enough pending metrics"
+
+    freq_map.each_value { |value| assert_equal 3, value, "metric counter mismatch"}
+
+    metrics_processor.send :run_one_iteration
+
+    assert_equal 0, freq_map.size, "not all pending metrics were flushed"
+
+
+    assert_equal 1, connector.get_captured_metrics.size
+
+
+    # if global target is set then targets should still include targets
+  end
+
+  def test_frequency_map_increment
+
+    map = MetricsProcessor::FrequencyMap.new
+
+    event1 = MetricsEvent.new(@feature1, @target, @variation1)
+    event2 = MetricsEvent.new(@feature2, @target, @variation2)
+
+    map.increment event1
+    map.increment event2
+
+    map.increment event1
+    map.increment event2
+
+    assert_equal 2, map[event1]
+    assert_equal 2, map[event2]
+  end
+
+  def test_frequency_map_drain_to_map
+    map = MetricsProcessor::FrequencyMap.new
+
+    event1 = MetricsEvent.new(@feature1, @target, @variation1)
+    event2 = MetricsEvent.new(@feature2, @target, @variation2)
+
+    map.increment event1
+    map.increment event2
+
+    map.increment event1
+    map.increment event2
+
+    new_map = map.drain_to_map
+
+    assert_equal 0, map.size
+    assert_equal 2, new_map[event1]
+    assert_equal 2, new_map[event2]
+  end
+
+  def test_comparable_metrics_event_equals_and_hash
+
+    event1 = MetricsEvent.new(@feature1, @target, @variation1)
+    event2 = MetricsEvent.new(@feature1, @target, @variation1)
+
+    assert(event1 == event2)
+
+    event1 = MetricsEvent.new(@feature1, @target, @variation1)
+    event2 = MetricsEvent.new(@feature2, @target, @variation2)
+
+    assert(event1 != event2)
+  end
+
+
+end


### PR DESCRIPTION
FFM-7285 - Remove Metrics queue and implement Map

What
Remove queue implementation and use a map to store metrics counts instead.

Why
Store each counter in a map for better memory performance. The current implementation adds a new row per eval. Using a queue can also fill up too quickly and cause the evaluation to block the user thread - until the metrics processor drains the queue which may be many seconds later.

Testing
Added new unit tests + manual