### PR TITLE
FFM-7325 - Improve authentication retry logic

### DIFF
--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -2,76 +2,80 @@ require_relative "../common/closeable"
 
 class AuthService < Closeable
 
-  def initialize(connector = nil, poll_interval_in_sec = 60, callback = nil, logger = nil)
+  def initialize(connector, callback, logger, retry_delay_ms = 6000)
 
     unless connector.kind_of?(Connector)
-
       raise "The 'connector' parameter must be of '" + Connector.to_s + "' data type"
     end
 
     unless callback.kind_of?(ClientCallback)
-
       raise "The 'callback' parameter must be of '" + ClientCallback.to_s + "' data type"
     end
 
+    @logger = logger
     @callback = callback
     @connector = connector
-    @poll_interval_in_sec = poll_interval_in_sec
-
-    if logger != nil
-
-      @logger = logger
-    else
-
-      @logger = Logger.new(STDOUT)
-    end
+    @retry_delay_ms = retry_delay_ms
+    @authenticated = false
   end
 
   def start_async
-
     @logger.debug "Async starting: " + self.to_s
 
-    @ready = true
+    @thread = Thread.new :report_on_exception => true do
+      attempt = 1
+      until @authenticated do
+        http_code = @connector.authenticate
 
-    @thread = Thread.new do
-
-      @logger.debug "Async started: " + self.to_s
-
-      while @ready do
-
-        @logger.debug "Async auth iteration"
-
-        if @connector.authenticate
-
+        if http_code == 200
+          @authenticated = true
           @callback.on_auth_success
           stop_async
-          @logger.info "Stopping Auth service"
+        elsif should_retry_http_code http_code
+          delay_ms = @retry_delay_ms * [10, attempt].min
+          @logger.warn "Got HTTP code #{http_code} while authenticating on attempt #{attempt}, will retry in #{delay_ms} ms"
+          sleep(delay_ms/1000)
+          attempt += 1
         else
-
-          @logger.error "Exception while authenticating, retry in " + @poll_interval_in_sec.to_s + " seconds"
+          @logger.warn "Auth Service got HTTP code #{http_code} while authenticating, will not attempt to reconnect"
+          @callback.on_auth_failed
+          stop_async
+          next
         end
-
-        sleep(@poll_interval_in_sec)
       end
     end
+
 
     @thread.run
   end
 
-  def close
+  def should_retry_http_code(code)
+    # 408 request timeout
+    # 425 too early
+    # 429 too many requests
+    # 500 internal server error
+    # 502 bad gateway
+    # 503 service unavailable
+    # 504 gateway timeout
+    case code
+    when 408,425,429,500,502,503,504
+      return true
+    else
+      return false
+    end
+  end
 
+
+  def close
     stop_async
   end
 
   def on_auth_success
 
-    unless @callback == nil
-
+    if @callback != nil
       unless @callback.kind_of?(ClientCallback)
-
         raise "Expected '" + ClientCallback.to_s + "' data type for the callback"
       end
-
       @callback.on_auth_success
     end
   end
@@ -80,12 +84,18 @@ class AuthService < Closeable
 
   def stop_async
 
-    @ready = false
 
     if @thread != nil
-
+      @logger.info "Stopping Auth service, status=#{@thread.status}"
       @thread.exit
       @thread = nil
+      @logger.info "Stopping Auth service done"
     end
+  end
+
+  private
+
+  def is_authenticated
+    @authenticated
   end
 end

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -65,8 +65,6 @@ class AuthService < Closeable
   end
 
   def stop_async
-
-
     if @thread != nil
       @logger.info "Stopping Auth service, status=#{@thread.status}"
       @thread.exit
@@ -89,8 +87,9 @@ class AuthService < Closeable
     # 502 bad gateway
     # 503 service unavailable
     # 504 gateway timeout
+    #  -1 OpenAPI error (timeout etc)
     case code
-    when 408,425,429,500,502,503,504
+    when 408,425,429,500,502,503,504,-1
       return true
     else
       return false

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -45,30 +45,14 @@ class AuthService < Closeable
       end
     end
 
-
     @thread.run
   end
-
-  def should_retry_http_code(code)
-    # 408 request timeout
-    # 425 too early
-    # 429 too many requests
-    # 500 internal server error
-    # 502 bad gateway
-    # 503 service unavailable
-    # 504 gateway timeout
-    case code
-    when 408,425,429,500,502,503,504
-      return true
-    else
-      return false
-    end
-  end
-
 
   def close
     stop_async
   end
+
+  protected
 
   def on_auth_success
 
@@ -79,8 +63,6 @@ class AuthService < Closeable
       @callback.on_auth_success
     end
   end
-
-  protected
 
   def stop_async
 
@@ -97,5 +79,21 @@ class AuthService < Closeable
 
   def is_authenticated
     @authenticated
+  end
+
+  def should_retry_http_code(code)
+    # 408 request timeout
+    # 425 too early
+    # 429 too many requests
+    # 500 internal server error
+    # 502 bad gateway
+    # 503 service unavailable
+    # 504 gateway timeout
+    case code
+    when 408,425,429,500,502,503,504
+      return true
+    else
+      return false
+    end
   end
 end

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -36,6 +36,7 @@ class AuthService < Closeable
           @logger.warn "Got HTTP code #{http_code} while authenticating on attempt #{attempt}, will retry in #{delay_ms} ms"
           sleep(delay_ms/1000)
           attempt += 1
+          @logger.info "Retrying to authenticate, attempt #{attempt}..."
         else
           @logger.warn "Auth Service got HTTP code #{http_code} while authenticating, will not attempt to reconnect"
           @callback.on_auth_failed

--- a/lib/ff/ruby/server/sdk/api/client_callback.rb
+++ b/lib/ff/ruby/server/sdk/api/client_callback.rb
@@ -2,44 +2,49 @@ require_relative "../common/closeable"
 
 class ClientCallback < Closeable
 
+  TBI = RuntimeError.new("To be implemented")
+
   def initialize
     super
-
-    @tbi = "To be implemented"
   end
 
   def on_auth_success
 
-    raise @tbi
+    raise TBI
+  end
+
+  def on_auth_failed
+
+    raise TBI
   end
 
   def on_authorized
 
-    raise @tbi
+    raise TBI
   end
 
   def is_closing
 
-    raise @tbi
+    raise TBI
   end
 
   def on_processor_ready(processor)
 
-    raise @tbi
+    raise TBI
   end
 
   def on_update_processor_ready
 
-    raise @tbi
+    raise TBI
   end
 
   def on_metrics_processor_ready
 
-    raise @tbi
+    raise TBI
   end
 
   def update(message, manual)
 
-    raise @tbi
+    raise TBI
   end
 end

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -94,7 +94,15 @@ class InnerClient < ClientCallback
       return
     end
 
-    on_auth_done
+    @poll_processor.start
+
+    if @config.stream_enabled
+      @update_processor.start
+    end
+
+    if @config.analytics_enabled
+      @metrics_processor.start
+    end
 
   end
 
@@ -102,7 +110,6 @@ class InnerClient < ClientCallback
     @config.logger.warn "Authentication failed with a non-recoverable error - defaults will be served"
     @initialized = true
 
-    on_auth_done
   end
 
   def close
@@ -312,15 +319,4 @@ class InnerClient < ClientCallback
     @my_mutex.synchronize(&block)
   end
 
-  def on_auth_done
-    @poll_processor.start
-
-    if @config.stream_enabled
-      @update_processor.start
-    end
-
-    if @config.analytics_enabled
-      @metrics_processor.start
-    end
-  end
 end

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -280,8 +280,7 @@ class InnerClient < ClientCallback
     @auth_service = AuthService.new(
       connector = @connector,
       callback = self,
-      logger = @config.logger,
-      poll_interval_in_sec = @config.poll_interval_in_seconds
+      logger = @config.logger
     )
 
     @poll_processor = PollingProcessor.new

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -37,14 +37,13 @@ class HarnessConnector < Connector
 
       @config.logger.info "Token has been obtained"
       process_token
-      return true
+      return 200
 
     rescue OpenapiClient::ApiError => e
 
       log_error(e)
+      return e.code
     end
-
-    false
   end
 
   def get_flags
@@ -60,6 +59,7 @@ class HarnessConnector < Connector
     rescue OpenapiClient::ApiError => e
 
       log_error(e)
+      return nil
     end
   end
 
@@ -76,6 +76,7 @@ class HarnessConnector < Connector
     rescue OpenapiClient::ApiError => e
 
       log_error(e)
+      return nil
     end
   end
 
@@ -239,6 +240,12 @@ class HarnessConnector < Connector
 
   def log_error(e)
 
-    @config.logger.error "ERROR - Start\n\n" + e.to_s + "\nERROR - End"
+    if e.code == 0
+      type = "typhoeus/libcurl"
+    else
+      type = "HTTP code #{e.code}"
+    end
+
+    @config.logger.warn "OpenapiClient::ApiError (#{type}) [\n\n" + e.to_s + "\n]"
   end
 end

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -41,6 +41,14 @@ class HarnessConnector < Connector
 
     rescue OpenapiClient::ApiError => e
 
+      if e.message.include? "the server returns an error"
+        # NOTE openapi-generator 5.2.1 has a bug where exceptions don't contain any useful information and we can't
+        # determine if a timeout has occurred. This is fixed in 6.3.0 but requires Ruby version to be increased to 2.7
+        # https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0
+        @config.logger.warn "OpenapiClient::ApiError [\n\n#{e}\n]"
+        return -1
+      end
+
       log_error(e)
       return e.code
     end

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -175,6 +175,8 @@ class HarnessConnector < Connector
     api_client = OpenapiClient::ApiClient.new
 
     api_client.config = @config
+    api_client.config.connection_timeout = @config.read_timeout / 1000
+    api_client.config.read_timeout = @config.read_timeout / 1000
     api_client.user_agent = @user_agent
     api_client.default_headers['Harness-SDK-Info'] = @sdk_info
 

--- a/test/ff/ruby/server/sdk/auth_service_test.rb
+++ b/test/ff/ruby/server/sdk/auth_service_test.rb
@@ -1,0 +1,100 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk"
+require "concurrent/atomics"
+
+class AuthServiceTest < Minitest::Test
+
+  class ReturnHttpCodeConnector < Connector
+    def initialize(http_code)
+      @http_code = http_code
+    end
+    def authenticate
+      puts "got auth, return with http code #{@http_code}"
+      @http_code
+    end
+  end
+
+  class FailThenRecoverConnector < Connector
+
+    def initialize(http_code)
+      @http_code = http_code
+      @auth_count = 0
+    end
+    def authenticate
+      @auth_count += 1
+      if @auth_count < 5
+        puts "got auth, return with http code #{@http_code}"
+        @http_code
+      else
+        puts "got auth, return 200"
+        200
+      end
+    end
+
+    def get_auth_count
+      @auth_count
+    end
+  end
+
+  class AuthSuccessCallback < ClientCallback
+
+    def initialize
+      @auth_success_latch = Concurrent::CountDownLatch.new(1)
+    end
+
+    def on_auth_success
+      @auth_success_latch.count_down
+    end
+
+    def on_auth_failed
+      raise "on_auth_failed should not be called"
+    end
+
+    def wait_for_auth_or_timeout
+      @auth_success_latch.wait 30
+    end
+  end
+
+  class AuthFailedCallback < ClientCallback
+
+    def initialize
+      @auth_failed_latch = Concurrent::CountDownLatch.new(1)
+    end
+
+    def on_auth_failed
+      @auth_failed_latch.count_down
+    end
+
+    def wait_for_auth_failure_or_timeout
+      @auth_failed_latch.wait 30000
+    end
+  end
+
+  # auth has outright failed and will not be reattempted
+  [401,403,404].each do |http_code|
+    define_method("test_should_not_retry_on_#{http_code}") do
+      callback = AuthFailedCallback.new
+      service = AuthService.new ReturnHttpCodeConnector.new(http_code), callback, Logger.new(STDOUT)
+      service.start_async
+      assert callback.wait_for_auth_failure_or_timeout, "timed out waiting for authentication to fail"
+      assert !(service.send :is_authenticated)
+    end
+  end
+
+  # auth has failed but will succeed in the future
+  [408,425,429,500,502,503,504].each do |http_code|
+    define_method("test_should_retry_on_#{http_code}") do
+      callback = AuthSuccessCallback.new
+      connector = FailThenRecoverConnector.new(http_code)
+      service = AuthService.new connector, callback, Logger.new(STDOUT), retry_delay_ms = 10
+      service.start_async
+      assert callback.wait_for_auth_or_timeout, "timed out waiting for authentication to succeed"
+      assert service.send :is_authenticated
+      assert_equal 5, connector.get_auth_count
+    end
+  end
+
+end
+
+
+

--- a/test/ff/ruby/server/sdk/cf_client_test.rb
+++ b/test/ff/ruby/server/sdk/cf_client_test.rb
@@ -1,0 +1,59 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk/api/config"
+require "ff/ruby/server/sdk/dto/target"
+require "ff/ruby/server/sdk/api/cf_client"
+require "ff/ruby/server/sdk/api/config_builder"
+require "logger"
+require "securerandom"
+require 'json'
+require 'socket'
+
+class CfClientTest < Minitest::Test
+
+  [401,403,404,408,425,429,500,502,503,504].each do |http_code|
+    define_method("test_serve_defaults_on_no_auth_#{http_code}") do
+
+      logger = Logger.new(STDOUT)
+      logger.level = Logger::DEBUG
+      logger.info "---------- TEST #{__method__} ----------"
+
+      port = rand(1000..9999)
+      Thread.new {
+        logger.info "listening on #{port}"
+        TCPServer.open("localhost", port) { |serve|
+          client = serve.accept
+          client.puts "HTTP/1.1 #{http_code} dummy http message"
+          client.puts
+          client.close
+        }
+        Thread.current.terminate
+      }
+
+      client = CfClient.new
+
+      client.init("DUMMY_KEY", ConfigBuilder.new.logger(logger)
+                                            .stream_enabled(false)
+                                            .analytics_enabled(false)
+                                            .event_url("http://localhost:#{port}/api/1.0")
+                                            .config_url("http://localhost:#{port}/api/1.0").build)
+
+      client.wait_for_initialization
+
+      target = Target.new("RubyTestSDK", identifier="rubytestsdk", attributes={"location": "emea"})
+
+      # assert that we get default values, even if we're still authenticating
+      [1..100].each do |n|
+        assert client.bool_variation("DUMMY_BOOL_FLAG", target, true)
+        assert !client.bool_variation("DUMMY_BOOL_FLAG", target, false)
+        assert_equal "STR1", client.string_variation("DUMMY_STR_FLAG", target, "STR1")
+        assert_equal "STR2", client.string_variation("DUMMY_STR_FLAG", target, "STR2")
+        assert_equal 123, client.string_variation("DUMMY_STR_FLAG", target, 123)
+        assert_equal 321, client.string_variation("DUMMY_STR_FLAG", target, 321)
+        assert_equal JSON.parse('{"test":"123"}'), client.json_variation("DUMMY_STR_FLAG", target, JSON.parse('{"test":"123"}'))
+        assert_equal JSON.parse('{"test":"321"}'), client.json_variation("DUMMY_STR_FLAG", target, JSON.parse('{"test":"321"}'))
+      end
+    end
+  end
+
+
+end

--- a/test/ff/ruby/server/sdk/cf_client_test.rb
+++ b/test/ff/ruby/server/sdk/cf_client_test.rb
@@ -29,7 +29,7 @@ class CfClientTest < Minitest::Test
         Thread.current.terminate
       }
 
-      client = CfClient.new
+      client = CfClient.instance
 
       client.init("DUMMY_KEY", ConfigBuilder.new.logger(logger)
                                             .stream_enabled(false)


### PR DESCRIPTION
FFM-7325 - Improve authentication retry logic

What
Harden the authentication retry logic to only retry on certain HTTP codes, certain error codes will be treated as transient and others not. We also want to ensure that while we are authenticating that default values will be served.

Why
We're doing a genernal review of network resiliency on auth and hardening code.

Testing
Manual + new unit tests added