### PR TITLE
FFM-7275 - Standardise SDK error codes

### DIFF
--- a/example/getting_started/getting_started.rb
+++ b/example/getting_started/getting_started.rb
@@ -8,6 +8,7 @@ require "securerandom"
 
 $stdout.sync = true
 logger = Logger.new $stdout
+logger.level = Logger::DEBUG
 
 # API Key
 apiKey = ENV['FF_API_KEY'] || 'changeme'

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -67,10 +67,10 @@ class AuthService < Closeable
 
   def stop_async
     if @thread != nil
-      @logger.info "Stopping Auth service, status=#{@thread.status}"
+      @logger.debug "Stopping Auth service, status=#{@thread.status}"
       @thread.exit
       @thread = nil
-      @logger.info "Stopping Auth service done"
+      @logger.debug "Stopping Auth service done"
     end
   end
 

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -36,7 +36,7 @@ class AuthService < Closeable
           @logger.warn "Got HTTP code #{http_code} while authenticating on attempt #{attempt}, will retry in #{delay_ms} ms"
           sleep(delay_ms/1000)
           attempt += 1
-          @logger.info "Retrying to authenticate, attempt #{attempt}..."
+          SdkCodes::warn_auth_retying @logger, attempt
         else
           @logger.warn "Auth Service got HTTP code #{http_code} while authenticating, will not attempt to reconnect"
           @callback.on_auth_failed

--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -3,6 +3,7 @@ require "murmurhash3"
 
 require_relative "evaluation"
 require_relative "../common/repository"
+require_relative "../common/sdk_codes"
 
 class Evaluator < Evaluation
 
@@ -33,6 +34,7 @@ class Evaluator < Evaluation
       return variation.value == "true"
     end
 
+    SdkCodes::warn_default_variation_served @logger, identifier, target, default_value.to_s
     default_value
   end
 
@@ -45,6 +47,7 @@ class Evaluator < Evaluation
       return variation.value
     end
 
+    SdkCodes::warn_default_variation_served @logger, identifier, target, default_value.to_s
     default_value
   end
 
@@ -57,6 +60,7 @@ class Evaluator < Evaluation
       return variation.value.to_i
     end
 
+    SdkCodes::warn_default_variation_served @logger, identifier, target, default_value.to_s
     default_value
   end
 
@@ -68,6 +72,7 @@ class Evaluator < Evaluation
       return variation.value.to_f
     end
 
+    SdkCodes::warn_default_variation_served @logger, identifier, target, default_value.to_s
     default_value
   end
 
@@ -80,6 +85,7 @@ class Evaluator < Evaluation
       return JSON.parse(variation.value)
     end
 
+    SdkCodes::warn_default_variation_served @logger, identifier, target, default_value.to_s
     default_value
   end
 

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -4,6 +4,7 @@ require "concurrent-ruby"
 require_relative "../dto/target"
 require_relative "../../sdk/version"
 require_relative "../common/closeable"
+require_relative "../common/sdk_codes"
 require_relative "../api/metrics_event"
 require_relative "../api/summary_metrics"
 
@@ -83,18 +84,18 @@ class MetricsProcessor < Closeable
   end
 
   def start
-    @config.logger.info "Starting metrics processor with request interval: " + @config.frequency.to_s
+    @config.logger.debug "Starting metrics processor with request interval: " + @config.frequency.to_s
     start_async
   end
 
   def stop
-    @config.logger.info "Stopping metrics processor"
+    @config.logger.debug "Stopping metrics processor"
     stop_async
   end
 
   def close
     stop
-    @config.logger.info "Closing metrics processor"
+    @config.logger.debug "Closing metrics processor"
   end
 
   def register_evaluation(target, feature_config, variation)
@@ -198,7 +199,7 @@ class MetricsProcessor < Closeable
       while @ready do
         unless @initialized
           @initialized = true
-          @config.logger.info "Metrics processor initialized"
+          SdkCodes::info_metrics_thread_started @config.logger
         end
         sleep(@config.frequency)
         run_one_iteration

--- a/lib/ff/ruby/server/sdk/api/polling_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/polling_processor.rb
@@ -29,13 +29,13 @@ class PollingProcessor < Closeable
 
     flags = []
 
-    @logger.info "Fetching flags started"
+    @logger.debug "Fetching flags started"
 
     result = @connector.get_flags
 
     if result != nil
 
-      @logger.info "Flags are fetched"
+      @logger.debug "Flags are fetched"
 
       result.each { |fc|
 
@@ -47,7 +47,7 @@ class PollingProcessor < Closeable
       }
     end
 
-    @logger.info "Fetching flags finished"
+    @logger.debug "Fetching flags finished"
 
     flags
   end
@@ -56,13 +56,13 @@ class PollingProcessor < Closeable
 
     segments = []
 
-    @logger.info "Fetching segments started"
+    @logger.debug "Fetching segments started"
 
     result = @connector.get_segments
 
     if result != nil
 
-      @logger.info "Segments are fetched"
+      @logger.debug "Segments are fetched"
 
       result.each { |s|
 
@@ -74,7 +74,7 @@ class PollingProcessor < Closeable
       }
     end
 
-    @logger.info "Fetching segments finished"
+    @logger.debug "Fetching segments finished"
 
     segments
   end
@@ -106,7 +106,7 @@ class PollingProcessor < Closeable
           unless @initialized
 
             @initialized = true
-            @logger.info "PollingProcessor initialized"
+            SdkCodes::info_poll_started(@logger, @poll_interval_in_sec)
 
             if @callback != nil
 
@@ -137,17 +137,16 @@ class PollingProcessor < Closeable
 
   def start
 
-    @logger.info "Starting PollingProcessor with request interval: " + @poll_interval_in_sec.to_s
+    @logger.debug "Starting PollingProcessor with request interval: " + @poll_interval_in_sec.to_s
     start_async
   end
 
   def stop
 
-    @logger.info "Stopping PollingProcessor"
+    @logger.debug "Stopping PollingProcessor"
     stop_async
     unless @ready
-
-      @logger.info "PollingProcessor stopped"
+      SdkCodes::info_polling_stopped @logger
     end
   end
 

--- a/lib/ff/ruby/server/sdk/api/update_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/update_processor.rb
@@ -105,8 +105,6 @@ class UpdateProcessor < Closeable
 
   def process_flag(message)
 
-    @logger.info "Processing flag message: " + message.to_s
-
     config = @connector.get_flag(message["identifier"])
 
     if config != nil

--- a/lib/ff/ruby/server/sdk/api/update_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/update_processor.rb
@@ -28,7 +28,7 @@ class UpdateProcessor < Closeable
 
   def start
 
-    @logger.info "Starting updater (EventSource)"
+    @logger.debug "Starting updater (EventSource)"
 
     if @updater != nil
 

--- a/lib/ff/ruby/server/sdk/common/sdk_codes.rb
+++ b/lib/ff/ruby/server/sdk/common/sdk_codes.rb
@@ -26,12 +26,20 @@ class SdkCodes
     logger.info SdkCodes.sdk_err_msg(5000)
   end
 
+  def self.info_stream_event_received(logger, event_json)
+    logger.info SdkCodes.sdk_err_msg(5002, event_json)
+  end
+
   def self.info_metrics_thread_started(logger)
     logger.info SdkCodes.sdk_err_msg(7000)
   end
 
   def self.warn_auth_failed_srv_defaults(logger)
     logger.warn SdkCodes.sdk_err_msg(2001)
+  end
+
+  def self.warn_auth_retying(logger, attempt)
+    logger.warn SdkCodes.sdk_err_msg(2003, ", attempt #{attempt}")
   end
 
   def self.warn_stream_disconnected(logger, reason)
@@ -43,7 +51,7 @@ class SdkCodes
   end
 
   def self.warn_default_variation_served(logger, identifier, target, default)
-    logger.warn SdkCodes.sdk_err_msg(6001, "identifier=%s, target=%s, default=%s" % [identifier, target, default])
+    logger.warn SdkCodes.sdk_err_msg(6001, "identifier=%s, target=%s, default=%s" % [identifier, target.identifier, default])
   end
 
   private
@@ -57,24 +65,26 @@ class SdkCodes
       # SDK_AUTH_2xxx
       2000 => "Authenticated ok",
       2001 => "Authentication failed with a non-recoverable error - defaults will be served",
-      # SDK_CLOSE_3xxx
+      2003 => "Retrying to authenticate",
       # SDK_POLL_4xxx
-      4000 => "Polling started, interval=",
+      4000 => "Polling started, intervalMs:",
       4001 => "Polling stopped",
-      # SDK_POLL_5xxx
+      # SDK_STREAM_5xxx
       5000 => "SSE stream connected ok",
-      5001 => "SSE stream disconnected, reason=",
+      5001 => "SSE stream disconnected, reason:",
+      5002 => "SSE event received: ",
+      5003 => "SSE retrying to connect in",
       # SDK_EVAL_6xxx
-      6000 => "Evaluated variation successfully:",
+      6000 => "Evaluated variation successfully",
       6001 => "Default variation was served",
       # SDK_METRICS_7xxx
       7000 => "Metrics thread started",
       7001 => "Metrics thread exited",
-      7002 => "Posting metrics failed, reason=",
+      7002 => "Posting metrics failed, reason:",
     }
 
   def self.sdk_err_msg(error_code, append_text = "")
-    "SDKCODE(#{error_code},#{get_err_class error_code}): #{@map[error_code]}#{append_text}"
+    "SDKCODE(%s:%s): %s %s" % [(get_err_class error_code), error_code, @map[error_code], append_text]
   end
 
   def self.get_err_class(error_code)

--- a/lib/ff/ruby/server/sdk/common/sdk_codes.rb
+++ b/lib/ff/ruby/server/sdk/common/sdk_codes.rb
@@ -1,0 +1,92 @@
+
+class SdkCodes
+  def self.raise_missing_sdk_key(logger)
+    msg = SdkCodes.sdk_err_msg(1002)
+    logger.error msg
+    raise msg
+  end
+
+  def self.info_poll_started(logger, durationSec)
+    logger.info SdkCodes.sdk_err_msg(4000, durationSec*1000)
+  end
+
+  def self.info_sdk_init_ok(logger)
+    logger.info SdkCodes.sdk_err_msg(1000)
+  end
+
+  def self.info_sdk_auth_ok(logger)
+    logger.info SdkCodes.sdk_err_msg(2000)
+  end
+
+  def self.info_polling_stopped(logger)
+    logger.info SdkCodes.sdk_err_msg(4001)
+  end
+
+  def self.info_stream_connected(logger)
+    logger.info SdkCodes.sdk_err_msg(5000)
+  end
+
+  def self.info_metrics_thread_started(logger)
+    logger.info SdkCodes.sdk_err_msg(7000)
+  end
+
+  def self.warn_auth_failed_srv_defaults(logger)
+    logger.warn SdkCodes.sdk_err_msg(2001)
+  end
+
+  def self.warn_stream_disconnected(logger, reason)
+    logger.warn SdkCodes.sdk_err_msg(5001, reason)
+  end
+
+  def self.warn_post_metrics_failed(logger, reason)
+    logger.warn SdkCodes.sdk_err_msg(7002, reason)
+  end
+
+  def self.warn_default_variation_served(logger, identifier, target, default)
+    logger.warn SdkCodes.sdk_err_msg(6001, "identifier=%s, target=%s, default=%s" % [identifier, target, default])
+  end
+
+  private
+
+  @map =
+    {
+      # SDK_INIT_1xxx
+      1000 => "The SDK has successfully initialized",
+      1001 => "The SDK has failed to initialize due to the following authentication error:",
+      1002 => "The SDK has failed to initialize due to a missing or empty API key",
+      # SDK_AUTH_2xxx
+      2000 => "Authenticated ok",
+      2001 => "Authentication failed with a non-recoverable error - defaults will be served",
+      # SDK_CLOSE_3xxx
+      # SDK_POLL_4xxx
+      4000 => "Polling started, interval=",
+      4001 => "Polling stopped",
+      # SDK_POLL_5xxx
+      5000 => "SSE stream connected ok",
+      5001 => "SSE stream disconnected, reason=",
+      # SDK_EVAL_6xxx
+      6000 => "Evaluated variation successfully:",
+      6001 => "Default variation was served",
+      # SDK_METRICS_7xxx
+      7000 => "Metrics thread started",
+      7001 => "Metrics thread exited",
+      7002 => "Posting metrics failed, reason=",
+    }
+
+  def self.sdk_err_msg(error_code, append_text = "")
+    "SDKCODE(#{error_code},#{get_err_class error_code}): #{@map[error_code]}#{append_text}"
+  end
+
+  def self.get_err_class(error_code)
+    if error_code >= 1000 and error_code <= 1999
+      return "init"
+    elsif error_code >= 2000 and error_code <= 2999 then return "auth"
+    elsif error_code >= 4000 and error_code <= 4999 then return "poll"
+    elsif error_code >= 5000 and error_code <= 5999 then return "stream"
+    elsif error_code >= 6000 and error_code <= 6999 then return "eval"
+    elsif error_code >= 7000 and error_code <= 7999 then return "metric"
+    end
+    ""
+  end
+
+end

--- a/lib/ff/ruby/server/sdk/connector/events.rb
+++ b/lib/ff/ruby/server/sdk/connector/events.rb
@@ -72,12 +72,13 @@ class Events < Service
   end
 
   def on_closed
-    SdkCodes::warn_stream_disconnected @logger, "closed"
+    SdkCodes::warn_stream_disconnected @logger, "on_closed called"
     @updater.on_disconnected
   end
 
   def on_message(message)
-    @logger.debug "EventSource message received " + message.to_s
+    SdkCodes::info_stream_event_received @logger, message.to_s
+
     msg = JSON.parse(message)
     @updater.update(msg)
   end

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -35,7 +35,7 @@ class HarnessConnector < Connector
       response = @api.authenticate(opts = options)
       @token = response.auth_token
 
-      @config.logger.info "Token has been obtained"
+      @config.logger.debug "Token has been obtained"
       process_token
       return 200
 
@@ -49,7 +49,7 @@ class HarnessConnector < Connector
         return -1
       end
 
-      log_error(e)
+      log_error("auth", e)
       return e.code
     end
   end
@@ -66,7 +66,7 @@ class HarnessConnector < Connector
 
     rescue OpenapiClient::ApiError => e
 
-      log_error(e)
+      log_error("get_feature_config", e)
       return nil
     end
   end
@@ -83,7 +83,7 @@ class HarnessConnector < Connector
 
     rescue OpenapiClient::ApiError => e
 
-      log_error(e)
+      log_error("get_all_segments", e)
       return nil
     end
   end
@@ -127,12 +127,11 @@ class HarnessConnector < Connector
         opts = options
       )
 
-      @config.logger.info "Successfully sent analytics data to the server"
+      @config.logger.debug "Successfully sent analytics data to the server"
 
     rescue OpenapiClient::ApiError => e
-
-      log_error(e)
-      @config.logger.error "Exception while posting metrics to the event server"
+      log_error("post_metrics", e)
+      SdkCodes.warn_post_metrics_failed @config.logger, e.message
     end
   end
 
@@ -248,7 +247,7 @@ class HarnessConnector < Connector
     }
   end
 
-  def log_error(e)
+  def log_error(prefix, e)
 
     if e.code == 0
       type = "typhoeus/libcurl"
@@ -256,6 +255,6 @@ class HarnessConnector < Connector
       type = "HTTP code #{e.code}"
     end
 
-    @config.logger.warn "OpenapiClient::ApiError (#{type}) [\n\n" + e.to_s + "\n]"
+    @config.logger.warn "%s: OpenapiClient::ApiError (%s) [\n\n%s\n]" % [prefix, type, e.to_s]
   end
 end

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.1.0"
+        VERSION = "1.1.1"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.1.0"
+export ff_ruby_sdk_version="1.1.1"

--- a/test/ff/ruby/server/sdk/sdk_code_test.rb
+++ b/test/ff/ruby/server/sdk/sdk_code_test.rb
@@ -1,0 +1,24 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk/common/sdk_codes"
+require 'ff/ruby/server/sdk/dto/target'
+
+class SdkCodeTest < Minitest::Test
+  def test_logs_dont_raise_exception
+    logger = Logger.new $stdout
+    logger.level = Logger::DEBUG
+    target = Target.new("RubySDK", identifier="rubysdk", attributes={"location": "emea"})
+
+    SdkCodes.info_poll_started logger, 10
+    SdkCodes.info_sdk_init_ok logger
+    SdkCodes.info_sdk_auth_ok logger
+    SdkCodes.info_polling_stopped logger
+    SdkCodes.info_stream_connected logger
+    SdkCodes.info_stream_event_received logger, ""
+    SdkCodes.info_metrics_thread_started logger
+    SdkCodes.warn_auth_failed_srv_defaults logger
+    SdkCodes.warn_auth_retying logger, 1
+    SdkCodes.warn_stream_disconnected logger, "example reason"
+    SdkCodes.warn_post_metrics_failed logger, "example reason"
+    SdkCodes.warn_default_variation_served logger, "identifier", target, "default"
+  end
+end


### PR DESCRIPTION
FFM-7275 - Standardise Init / Auth /  Close / Polling / Streaming / M…etrics log messages and error messages

What
Adding standardised SDK error codes + pushing some logs down to debug to reduce noise

Why
Each SDK uses different log messages for its lifecycle. We want to standardise messages across SDKs with a unique code.

Testing
Manual testing + unit testing