### PR TITLE
FFM-6503: Ruby SDK returns wrong evaluation when there are two equals in one group

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -225,13 +225,13 @@ class Evaluator < Evaluation
 
     clauses.each do |clause|
 
-      unless evaluate_clause(clause, target)
+      if evaluate_clause(clause, target)
 
-        return false
+        return true
       end
     end
 
-    true
+    false
   end
 
   def evaluate_clause(clause, target)


### PR DESCRIPTION
FFM-6503: Ruby SDK returns wrong evaluation when there are two equals rules in one group

What
Change loop to abort with true when first condition matches (OR) rather than expecting all condition to match (AND)

Why
Target groups clauses should be treated as logical ORs.

Testing
Tested with Ruby testgrid container and sdk_evaluation_test.go