### PR TITLE
FFM-7870 - Ruby SDK - IN operator for rules is broken

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -301,7 +301,7 @@ class Evaluator < Evaluation
 
     if operator == "in"
 
-      return object.include?(value)
+      return clause.values.include?(object)
     end
 
     if operator == "segmentMatch"


### PR DESCRIPTION
FFM-7870 - Ruby SDK - IN operator for rules is broken

What
Fix evaluation logic to correctly handle IN operator

Why
IN operator of Target Group Criteria incorrectly does a substring check of element 1 instead of checking all elements

Testing
The following testgrid tests are now working:

"GroupRules;Type=Bool;State=Enabled;InOneTwoThree;Should Return true for Target three"
"GroupRules;Type=Bool;State=Enabled;InONETWOTHREE;Should Return false for Target three"
"GroupRules;Type=Bool;State=Enabled;InOneTwoThree;Should Return false for Target THREE" 
"GroupRules;Type=Number;State=Enabled;InOneTwoThree;Should Return 324523 for Target three" 
"GroupRules;Type=String;State=Enabled;InOneTwoThree;Should Return theHobbit for Target three" 
"GroupRules;Type=Bool;State=Enabled;InONETWOTHREE;Should Return false for Target three"
"GroupRules;Type=Bool;State=Enabled;InOneTwoThree;Should Return false for Target THREE" 
"GroupRules;Type=JSON;State=Enabled;InOneTwoThree;Should Return emptyJSON for Target three"
