### PR TITLE
FFM-8670: Feature flag rule not being evaluated for a given attribute

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -142,7 +142,7 @@ class Evaluator < Evaluation
         return target.send(attribute)
       else
 
-        result = target.attributes.key?(attribute)
+        result = target.attributes[attribute.to_sym]
 
         if result == nil
 


### PR DESCRIPTION
Fix evaluation issue where a boolean is returned instead of a value. In the issue FFM-8670, the customer reported that flag was still returning the same true value, even though the flag was set and that boolean is compared against the list of IN clause values from the flag’s config, which always fails.