### PR TITLE
[FFM-8725] - Target attributes need to be defined as a hash instead of an array

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -142,6 +142,8 @@ class Evaluator < Evaluation
         return target.send(attribute)
       else
 
+        @logger.debug "target attrs: " + target.attributes.to_s
+
         result = target.attributes[attribute.to_sym]
 
         if result == nil

--- a/lib/ff/ruby/server/sdk/dto/target.rb
+++ b/lib/ff/ruby/server/sdk/dto/target.rb
@@ -6,7 +6,7 @@ class Target
 
     name,
     identifier = name,
-    attributes = [],
+    attributes = {},
     is_private = false
   )
 

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.1.2"
+        VERSION = "1.1.3"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.1.2"
+export ff_ruby_sdk_version="1.1.3"


### PR DESCRIPTION
[FFM-8725] - Target attributes need to be defined as a hash instead of an array

What
Set attributes to hash instead of array when none are given

Why
The following exception is seen when rules are defined with an empty set of attributes:
  evaluator.rb:148:in `get_attr_value': no implicit conversion of Symbol into Integer (TypeError)

Testing
New test added to TestEvaluations_ServerSDK see [FFM-8706]

[FFM-8725]: https://harness.atlassian.net/browse/FFM-8725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FFM-8706]: https://harness.atlassian.net/browse/FFM-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ