### PR TITLE
[FFM-9036] - Convert target attributes with string keys to symbol keys

### DIFF
--- a/lib/ff/ruby/server/sdk/dto/target.rb
+++ b/lib/ff/ruby/server/sdk/dto/target.rb
@@ -12,7 +12,7 @@ class Target
 
     @name = name
     @identifier = identifier
-    @attributes = attributes
+    @attributes = attributes.transform_keys(&:to_sym)
     @is_private = is_private
     @private_attributes = Set[]
   end

--- a/lib/ff/ruby/server/sdk/dto/target.rb
+++ b/lib/ff/ruby/server/sdk/dto/target.rb
@@ -12,7 +12,7 @@ class Target
 
     @name = name
     @identifier = identifier
-    @attributes = attributes.transform_keys(&:to_sym)
+    @attributes = attributes == nil ? {} : attributes.transform_keys(&:to_sym)
     @is_private = is_private
     @private_attributes = Set[]
   end

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.1.3"
+        VERSION = "1.1.4"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.1.3"
+export ff_ruby_sdk_version="1.1.4"

--- a/test/ff/ruby/server/sdk/target_test.rb
+++ b/test/ff/ruby/server/sdk/target_test.rb
@@ -1,0 +1,23 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk/dto/target"
+
+class TargetTest < Minitest::Test
+  def test_various_target_attrs
+    target = Target.new("test", identifier="test", nil)
+    assert_equal 0, target.attributes.size
+
+    target = Target.new("test", identifier="test", {} )
+    assert_equal 0, target.attributes.size
+
+    target = Target.new("test", identifier="test" )
+    assert_equal 0, target.attributes.size
+
+    target = Target.new("test", identifier="test", {test: "this_is_a_symbol_key"})
+    assert_equal 1, target.attributes.size
+    assert target.attributes[:test]
+
+    target = Target.new("test", identifier="test", {"test": "this_is_a_string_key"})
+    assert_equal 1, target.attributes.size
+    assert target.attributes[:test]
+  end
+end


### PR DESCRIPTION
[FFM-9036] - Convert target attributes with string keys to symbol keys

What
For any target attribute passed in with a string key convert them to a symbol key

Why
Make sure we’re internally consistent when handling keys

Testing
Manual + testgrid

[FFM-9036]: https://harness.atlassian.net/browse/FFM-9036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ