### PR TITLE
FFM-9804 Fix percentage rollout prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.0.0] ** BREAKING ** 
+
+- [FFM-9804] - The percentage rollout hash algorithm was slightly different compared to other Feature Flags SDKs, which resulted 
+in a different bucket allocation for the same target. While the overall percentage distribution was correct with the previous
+algorithm; this fix ensures that the same target will get the same allocation per SDK. We are marking as a breaking change
+as existing targets may get different allocations in a percentage rollout flag. 
+
 # [1.1.0]
 
 - [FFM-7285] - Remove Metrics queue and implement Map for better memory usage

--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -182,7 +182,7 @@ class Evaluator < Evaluation
 
   def get_normalized_number(property, bucket_by)
 
-    joined = property.to_s + ":" + bucket_by.to_s
+    joined = bucket_by.to_s + ":" + property.to_s
     hash = MurmurHash3::V32.str_hash(joined, joined.length)
     (hash % 100) + 1
   end

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.1.4"
+        VERSION = "2.0.0"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.1.4"
+export ff_ruby_sdk_version="2.0.0"


### PR DESCRIPTION
# What 

Updates percentage rollout prefix to align with other SDKs. 

# Why

The prefix is backwards in this SDK, and Ruby, compared to our other SDKs. 

# Testing

Manual - compared hash for given target with Golang SDK