### PR TITLE
[FFM-10177] - Ruby SDK - Use pessimistic version operator for minor versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cache
 moneta
 
 example.log
+/node_modules/
+package.json
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.2.1]
+
+- [FFM-10177] - Ruby SDK - Use pessimistic version operator for minor versions
+
 # [1.2.0] ** BREAKING **
 
 - [FFM-9804] - The percentage rollout hash algorithm was slightly different compared to other Feature Flags SDKs, which resulted 

--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,4 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-
 gemspec
-
-gem "rake", "~> 13.0"
-gem "minitest", "~> 5.0"
-gem "standard", "~> 1.3"
-
-# Caching support:
-gem "rufus-scheduler", "~> 3.8"
-gem "libcache", "0.4.2"
-gem "jwt", "~> 2.3"
-gem "moneta", "~> 1.4"
-
-# SSE support:
-gem "rest-client", "~> 2.1"
-
-# Concurrency support:
-gem "concurrent-ruby", "~> 1.1", require: "concurrent"
-
-# Evaluator dependencies:
-gem "murmurhash3", "~> 0.1.6"
-
-gem "typhoeus"
-
-group :test do
-  gem 'simplecov', '~> 0.21.2'
-end
-

--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-system "sh scripts/openapi.sh lib/ff/ruby/server/generated"
+
+if not Dir.exist?("lib/ff/ruby/server/generated")
+  puts "Generating OpenAPI sources..."
+  system "sh scripts/openapi.sh lib/ff/ruby/server/generated"
+else
+  puts "OpenAPI sources found"
+end if
 
 require_relative "lib/ff/ruby/server/sdk/version"
 
@@ -42,14 +48,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "minitest", "~> 5.0"
   spec.add_dependency "standard", "~> 1.3"
 
-  spec.add_dependency "rufus-scheduler", "3.8.1"
+  spec.add_dependency "rufus-scheduler", "~> 3.8"
   spec.add_dependency "libcache", "0.4.2"
-  spec.add_dependency "jwt", "2.3.0"
-  spec.add_dependency "moneta", "1.4.2"
+  spec.add_dependency "jwt", "~> 2.3"
+  spec.add_dependency "moneta", "~> 1.4"
 
-  spec.add_dependency "rest-client", "2.1.0"
+  spec.add_dependency "rest-client", "~> 2.1"
 
-  spec.add_dependency "concurrent-ruby", "1.1.10"
+  spec.add_dependency "concurrent-ruby", "~> 1.1"
 
   spec.add_dependency "murmurhash3", "0.1.6"
 

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.2.0"
+        VERSION = "1.2.1"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.2.0"
+export ff_ruby_sdk_version="1.2.1"


### PR DESCRIPTION
[FFM-10177] - Ruby SDK - Use pessimistic version operator for minor versions

**What**
- Use pessimistic version operator for minor versions
- Small fix to gemspec to only generate api code if not already done

**Why**
To loosen version requirements and allow easier integration of dependencies

**Testing**
Manual + testgrid