### PR TITLE
[FFM-10418] - test_polling_processor breaks nightly builds

### DIFF
--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.2.0"
+        VERSION = "1.2.1"
       end
     end
   end

--- a/test/ff/ruby/server/sdk/sdk_test.rb
+++ b/test/ff/ruby/server/sdk/sdk_test.rb
@@ -301,11 +301,11 @@ class Ff::Ruby::Server::SdkTest < Minitest::Test
 
     processor.start
 
-    sleep(1)
+    sleep(2)
 
     assert_equal(1, callback.on_poller_ready_count)
     assert_equal(0, callback.on_poller_error_count)
-    assert_equal(10, callback.on_poller_iteration_count)
+    assert(callback.on_poller_iteration_count >= 10)
 
     processor.close
 


### PR DESCRIPTION
**What**
Relax test assertion since polling processor can’t always guarantee 10 iterations on slower processors (e.g. CI).

**Why**
The following assertion is failing because it is too precise

Ff::Ruby::Server::SdkTest#test_polling_processor [test/ff/ruby/server/sdk/sdk_test.rb:308]

**Testing**
Manual