### PR TITLE
[FFM-11241] - Target v2: Adding support for AND/OR in clauses

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -14,6 +14,8 @@ servers:
 tags:
   - name: client
   - name: metrics
+  - name: Proxy
+    description: APIs used by the ff-proxy
 paths:
   '/client/env/{environmentUUID}/feature-configs':
     get:
@@ -29,8 +31,9 @@ paths:
           description: Unique identifier for the environment object in the API.
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -59,8 +62,9 @@ paths:
           description: Unique identifier for the environment object in the API.
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -82,8 +86,9 @@ paths:
           description: Unique identifier for the environment object in the API.
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -121,8 +126,9 @@ paths:
           description: Unique identifier for the environment object in the API
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -184,8 +190,9 @@ paths:
           description: Unique identifier for the target object in the API.
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -194,10 +201,7 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Pagination'
-                  - type: object
-                    properties:
-                      evaluations:
-                        $ref: '#/components/schemas/Evaluations'
+                  - $ref: '#/components/schemas/Evaluations'
   '/client/env/{environmentUUID}/target/{target}/evaluations/{feature}':
     get:
       summary: Get feature evaluations for target
@@ -223,8 +227,9 @@ paths:
           description: Unique identifier for the target object in the API.
           schema:
             type: string
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -232,7 +237,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Evaluation'
-  '/metrics/{environment}':
+  '/metrics/{environmentUUID}':
     post:
       tags:
         - metrics
@@ -241,13 +246,15 @@ paths:
       operationId: postMetrics
       parameters:
         - $ref: '#/components/parameters/environmentPathParam'
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Metrics'
       security:
-        - BearerAuth: [ ]
+        - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -269,8 +276,9 @@ paths:
           schema:
             type: string
           required: true
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       security:
-        - BearerAuth: [ ]
+        - BearerAuth: []
       responses:
         '200':
           description: OK
@@ -293,65 +301,175 @@ paths:
                 default: '*'
         '503':
           description: Service Unavailable
+  /proxy/config:
+    get:
+      summary: Gets Proxy config for multiple environments
+      description: >-
+        Gets Proxy config for multiple environments if the Key query param is
+        provided or gets config for a single environment if an environment query
+        param is provided
+      operationId: GetProxyConfig
+      tags:
+        - Proxy
+      parameters:
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - in: query
+          name: environment
+          description: >-
+            Accepts an EnvironmentID. If this is provided then the endpoint will
+            only return config for this environment. If this is left empty then
+            the Proxy will return config for all environments associated with
+            the Proxy Key.
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: key
+          description: Accpets a Proxy Key.
+          required: true
+          schema:
+            type: string
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/ProxyConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /proxy/auth:
+    post:
+      summary: Endpoint that the Proxy can use to authenticate with the client server
+      description: Endpoint that the Proxy can use to authenticate with the client server
+      operationId: AuthenticateProxyKey
+      tags:
+        - Proxy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                proxyKey:
+                  type: string
+                  example: 896045f3-42ee-4e73-9154-086644768b96
+              required:
+                - proxyKey
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     FeatureState:
       type: string
+      description: The state of a flag either off or on
       enum:
         - 'on'
         - 'off'
     Variation:
       type: object
+      description: A variation of a flag that can be returned to a target
       properties:
         identifier:
           type: string
+          description: The unique identifier for the variation
+          example: off-variation
         value:
           type: string
+          description: >-
+            The variation value to serve such as true or false for a boolean
+            flag
+          example: 'true'
         name:
           type: string
+          description: The user friendly name of the variation
+          example: Off VAriation
         description:
           type: string
+          description: A description of the variation
       required:
         - identifier
         - value
     Clause:
       type: object
+      description: A clause describes what conditions are used to evaluate a flag
       properties:
         id:
           type: string
+          description: The unique ID for the clause
+          example: 32434243
         attribute:
           type: string
+          description: >-
+            The attribute to use in the clause.  This can be any target
+            attribute
+          example: identifier
         op:
           type: string
+          description: 'The type of operation such as equals, starts_with, contains'
+          example: starts_with
         values:
           type: array
+          description: The values that are compared against the operator
           items:
             type: string
         negate:
           type: boolean
+          description: Is the operation negated?
+          example: false
       required:
-        - id
         - attribute
         - op
         - negate
         - values
     WeightedVariation:
       type: object
+      description: >-
+        A variation and the weighting it should receive as part of a percentage
+        rollout
       properties:
         variation:
           type: string
+          description: The variation identifier
+          example: off-variation
         weight:
           type: integer
+          description: The weight to be given to the variation in percent
+          example: 50
       required:
         - variation
         - weight
     Distribution:
       type: object
+      description: Describes a distribution rule
       properties:
         bucketBy:
           type: string
+          description: The attribute to use when distributing targets across buckets
         variations:
           type: array
+          description: A list of variations and the weight that should be given to each
           items:
             $ref: '#/components/schemas/WeightedVariation'
       required:
@@ -359,6 +477,9 @@ components:
         - variations
     Serve:
       type: object
+      description: >-
+        Describe the distribution rule and the variation that should be served
+        to the target
       properties:
         distribution:
           $ref: '#/components/schemas/Distribution'
@@ -366,13 +487,20 @@ components:
           type: string
     ServingRule:
       type: object
+      description: The rule used to determine what variation to serve to a target
       properties:
         ruleId:
           type: string
+          description: The unique identifier for this rule
         priority:
           type: integer
+          description: >-
+            The rules priority relative to other rules.  The rules are evaluated
+            in order with 1 being the highest
+          example: 1
         clauses:
           type: array
+          description: A list of clauses to use in the rule
           items:
             $ref: '#/components/schemas/Clause'
         serve:
@@ -381,14 +509,16 @@ components:
         - priority
         - clauses
         - serve
-        - ruleId
     Prerequisite:
       type: object
+      description: Feature Flag pre-requisites
       properties:
         feature:
           type: string
+          description: The feature identifier that is the prerequisite
         variations:
           type: array
+          description: A list of variations that must be met
           items:
             type: string
       required:
@@ -396,25 +526,35 @@ components:
         - variations
     TargetMap:
       type: object
+      description: Target map provides the details of a target that belongs to a flag
       properties:
         identifier:
           type: string
+          description: The identifier for the target
         name:
           type: string
+          description: The name of the target
       required:
-        - idenfifier
+        - identifier
         - name
     VariationMap:
       type: object
+      description: >-
+        A mapping of variations to targets and target groups (segments).  The
+        targets listed here should receive this variation.
       properties:
         variation:
           type: string
+          description: The variation identifier
+          example: off-variation
         targets:
           type: array
+          description: A list of target mappings
           items:
             $ref: '#/components/schemas/TargetMap'
         targetSegments:
           type: array
+          description: A list of target groups (segments)
           items:
             type: string
       required:
@@ -468,86 +608,123 @@ components:
         - state
         - kind
         - variations
-        - defaultTarget
         - offVariation
         - defaultServe
     Tag:
       type: object
-      description: A name and value pair.
+      description: A Tag object used to tag feature flags - consists of name and identifier
       properties:
         name:
           type: string
-        value:
+          description: The name of the tag
+          example: feature-flag-tag-1
+        identifier:
           type: string
+          description: The identifier of the tag
+          example: feature-flag-tag-1
       required:
         - name
+        - identifier
     Segment:
       type: object
+      description: A Target Group (Segment) response
       properties:
         identifier:
           type: string
-          description: Unique identifier for the segment.
+          description: Unique identifier for the target group.
         name:
           type: string
-          description: Name of the segment.
+          description: Name of the target group.
           example: Beta Testers
         environment:
           type: string
+          description: The environment this target group belongs to
+          example: Production
         tags:
           type: array
+          description: Tags for this target group
           items:
             $ref: '#/components/schemas/Tag'
         included:
           type: array
+          description: A list of Targets who belong to this target group
           items:
             $ref: '#/components/schemas/Target'
         excluded:
           type: array
+          description: A list of Targets who are excluded from this target group
           items:
             $ref: '#/components/schemas/Target'
         rules:
           type: array
           items:
             $ref: '#/components/schemas/Clause'
+        servingRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupServingRule'
           description: >-
             An array of rules that can cause a user to be included in this
             segment.
         createdAt:
           type: integer
+          description: The data and time in milliseconds when the group was created
           format: int64
         modifiedAt:
           type: integer
+          description: The data and time in milliseconds when the group was last modified
           format: int64
         version:
           type: integer
+          description: >-
+            The version of this group.  Each time it is modified the version is
+            incremented
+          example: 1
           format: int64
       required:
         - identifier
         - name
     Target:
       type: object
+      description: A Target object
       properties:
         identifier:
           type: string
+          description: The unique identifier for this target
+          example: john-doe
         account:
           type: string
+          description: The account ID that the target belongs to
+          example: abcXDdffdaffd
         org:
           type: string
+          description: The identifier for the organization that the target belongs to
         environment:
           type: string
+          description: The identifier for the environment that the target belongs to
         project:
           type: string
+          description: The identifier for the project that this target belongs to
         name:
           type: string
+          description: The name of this Target
+          example: John Doe
         anonymous:
           type: boolean
+          description: Indicates if this target is anonymous
         attributes:
           type: object
+          description: a JSON representation of the attributes for this target
+          example:
+            age: 20
+            location: Belfast
         createdAt:
           type: integer
+          description: The date and time in milliseconds when this Target was created
           format: int64
         segments:
           type: array
+          description: A list of Target Groups (Segments) that this Target belongs to
           items:
             $ref: '#/components/schemas/Segment'
       required:
@@ -557,13 +734,42 @@ components:
         - project
         - account
         - org
+    GroupServingRule:
+      type: object
+      description: The rule used to determine what variation to serve to a target
+      properties:
+        ruleId:
+          type: string
+          description: The unique identifier for this rule
+        priority:
+          type: integer
+          description: >-
+            The rules priority relative to other rules.  The rules are evaluated
+            in order with 1 being the highest
+          example: 1
+        clauses:
+          type: array
+          description: A list of clauses to use in the rule
+          items:
+            $ref: '#/components/schemas/Clause'
+      required:
+        - ruleId
+        - clauses
+        - priority
     Error:
       type: object
       properties:
         code:
           type: string
+          description: The http error code
+          example: 404
         message:
           type: string
+          description: The reason the request failed
+          example: 'Error retrieving projects, organization ''default_org'' does not exist'
+        details:
+          type: object
+          description: Additional details about the error
       required:
         - code
         - message
@@ -600,22 +806,30 @@ components:
       properties:
         version:
           type: integer
+          description: >-
+            The version of this object.  The version will be incremented each
+            time the object is modified
+          example: 5
         pageCount:
           type: integer
+          description: The total number of pages
+          example: 100
         itemCount:
           type: integer
+          description: The total number of items
           example: 1
         pageSize:
           type: integer
+          description: The number of items per page
           example: 1
         pageIndex:
           type: integer
+          description: The current page
           example: 0
       required:
         - pageCount
         - itemCount
         - pageSize
-        - pageIndex
         - pageIndex
     Evaluation:
       type: object
@@ -696,11 +910,69 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetricsData'
+    ProxyConfig:
+      type: object
+      description: TBD
+      allOf:
+        - $ref: '#/components/schemas/Pagination'
+        - properties:
+            environments:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  apiKeys:
+                    type: array
+                    items:
+                      type: string
+                  featureConfigs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FeatureConfig'
+                  segments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Segment'
   securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: api-key
     BearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    clusterQueryOptionalParam:
+      name: cluster
+      in: query
+      required: false
+      description: Unique identifier for the cluster for the account
+      schema:
+        type: string
+    environmentPathParam:
+      name: environmentUUID
+      in: path
+      required: true
+      description: environment parameter in query.
+      schema:
+        type: string
+    pageNumber:
+      name: pageNumber
+      in: query
+      required: false
+      description: PageNumber
+      schema:
+        type: integer
+    pageSize:
+      name: pageSize
+      in: query
+      required: false
+      description: PageSize
+      schema:
+        type: integer
   responses:
     Unauthenticated:
       description: Unauthenticated
@@ -726,11 +998,15 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-  parameters:
-    environmentPathParam:
-      name: environment
-      in: path
-      required: true
-      description: environment parameter in query.
-      schema:
-        type: string
+    ProxyConfigResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProxyConfig'
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.2.1"
+        VERSION = "1.3.0"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.2.1"
+export ff_ruby_sdk_version="1.3.0"

--- a/test/ff/ruby/server/sdk/evaluator_test.rb
+++ b/test/ff/ruby/server/sdk/evaluator_test.rb
@@ -1,0 +1,96 @@
+require "minitest/autorun"
+require "ff/ruby/server/sdk/common/repository"
+require "ff/ruby/server/sdk/api/default_cache"
+require "ff/ruby/server/sdk/api/storage_repository"
+require "ff/ruby/server/sdk/api/evaluator"
+require "ff/ruby/server/sdk/dto/target"
+require "ff/ruby/server/generated/lib/openapi_client/models/feature_config"
+require "ff/ruby/server/generated/lib/openapi_client/models/feature_state"
+require "ff/ruby/server/generated/lib/openapi_client/models/segment"
+require "ff/ruby/server/generated/lib/openapi_client/models/variation"
+require "ff/ruby/server/generated/lib/openapi_client/models/distribution"
+require "ff/ruby/server/generated/lib/openapi_client/models/serve"
+require "ff/ruby/server/generated/lib/openapi_client/models/variation_map"
+require "ff/ruby/server/generated/lib/openapi_client/models/clause"
+require "ff/ruby/server/generated/lib/openapi_client/models/group_serving_rule"
+require 'json'
+
+class EvaluatorTest < Minitest::Test
+
+  [
+    #
+    # if (target.attr.email endswith '@harness.io' && target.attr.role = 'developer')
+    #
+    {name: "email_is_dev", email: "user@harness.io", role: "developer", expected: true},
+    {name: "email_is_mgr", email: "user@harness.io", role: "manager", expected: false},
+    {name: "external_email_is_dev", email: "user@gmail.com", role: "developer", expected: false},
+    {name: "external_email_is_mgr", email: "user@gmail.com", role: "manager", expected: false},
+
+  ].each do | test_case |
+
+    define_method("test_target_v2_and_operator__#{test_case[:name]}") do
+      flag_name = "boolflag_and"
+
+      cache = DefaultCache.new
+      repo = StorageRepository.new cache
+      load_flags repo, "#{__dir__}/local-test-cases/v2-andor-flags.json"
+      load_segments repo, "#{__dir__}/local-test-cases/v2-andor-segments.json"
+      evaluator = Evaluator.new repo
+
+      target = Target.new("test", identifier="test", attributes={"email": test_case[:email], "role": test_case[:role]})
+      result = evaluator.evaluate(flag_name, target, "boolean", nil)
+      assert_equal test_case[:expected].to_s, result.value
+    end
+  end
+
+
+  [
+    #
+    # if (target.attr.email endswith '@harness.io' || target.attr.email endswith '@gmail.com'
+    #
+    {name: "email_is_harness", email: "user@harness.io", role: "developer", expected: true},
+    {name: "email_is_something_else", email: "user@harness.io", role: "manager", expected: true},
+    {name: "email_is_gmail", email: "user@gmail.com", role: "developer", expected: false},
+
+  ].each do | test_case |
+
+    define_method("test_target_v2_or_operator__#{test_case[:name]}") do
+      flag_name = "boolflag_or"
+
+      cache = DefaultCache.new
+      repo = StorageRepository.new cache
+      load_flags repo, "#{__dir__}/local-test-cases/v2-andor-flags.json"
+      load_segments repo, "#{__dir__}/local-test-cases/v2-andor-segments.json"
+      evaluator = Evaluator.new repo
+
+      target = Target.new("test", identifier="test", attributes={"email": test_case[:email], "role": test_case[:role]})
+      result = evaluator.evaluate(flag_name, target, "boolean", nil)
+      assert_equal test_case[:expected].to_s, result.value
+    end
+  end
+
+
+
+  def load_flags repo, json_file
+    loaded = JSON.load File.new(json_file), nil, {symbolize_names: true, create_additions: false}
+    loaded.each do |flag_json|
+
+      klass = OpenapiClient.const_get('FeatureConfig')
+      flag = klass.respond_to?(:openapi_one_of) ? klass.build(flag_json) : klass.build_from_hash(flag_json)
+
+      repo.set_flag(flag.feature, flag)
+    end
+  end
+
+  def load_segments repo, json_file
+    loaded = JSON.load File.new(json_file), nil, {symbolize_names: true, create_additions: false}
+    loaded.each do |segment_json|
+
+      klass = OpenapiClient.const_get('Segment')
+      segment = klass.respond_to?(:openapi_one_of) ? klass.build(segment_json) : klass.build_from_hash(segment_json)
+
+      repo.set_segment(segment.identifier, segment)
+    end
+  end
+
+end

--- a/test/ff/ruby/server/sdk/local-test-cases/v2-andor-flags.json
+++ b/test/ff/ruby/server/sdk/local-test-cases/v2-andor-flags.json
@@ -1,0 +1,69 @@
+[
+  {
+    "defaultServe": {
+      "variation": "false",
+      "distribution": null
+    },
+    "environment": "TEST",
+    "feature": "boolflag_or",
+    "kind": "boolean",
+    "offVariation": "false",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": [
+      {
+        "variation": "true",
+        "targets": [],
+        "targetSegments": ["or-segment"]
+      }
+    ],
+    "variations": [
+      {
+        "identifier": "true",
+        "name": "True",
+        "value": "true"
+      },
+      {
+        "identifier": "false",
+        "name": "False",
+        "value": "false"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "defaultServe": {
+      "variation": "false"
+    },
+    "environment": "TEST",
+    "feature": "boolflag_and",
+    "kind": "boolean",
+    "offVariation": "false",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": [
+      {
+        "variation": "true",
+        "targets": [],
+        "targetSegments": ["and-segment"]
+      }
+    ],
+    "variations": [
+      {
+        "identifier": "true",
+        "name": "True",
+        "value": "true"
+      },
+      {
+        "identifier": "false",
+        "name": "False",
+        "value": "false"
+      }
+    ],
+    "version": 1
+  }
+]

--- a/test/ff/ruby/server/sdk/local-test-cases/v2-andor-segments.json
+++ b/test/ff/ruby/server/sdk/local-test-cases/v2-andor-segments.json
@@ -1,0 +1,95 @@
+[
+  {
+    "environment": "Production",
+    "excluded": [],
+    "identifier": "or-segment",
+    "included": [],
+    "name": "is_harness_or_somethingelse_email_OR",
+    "rules": [
+      {
+        "attribute": "identifier",
+        "id": "7ccfe4f4-b5b4-4d45-9eae-ce2666210487",
+        "negate": false,
+        "op": "ends_with",
+        "values": [
+          "@harness.io"
+        ]
+      }
+    ],
+
+    "servingRules": [
+      {
+        "ruleId": "this_rule_with_lower_priority_should_be_ignored",
+        "priority": 7,
+        "clauses": [
+          {
+            "attribute": "email",
+            "op": "ends_with",
+            "values": [
+              "@harness.io"
+            ]
+          }
+        ]
+      },
+      {
+        "ruleId": "rule1",
+        "priority": 1,
+        "clauses": [
+          {
+            "attribute": "email",
+            "op": "ends_with",
+            "values": [
+              "@harness.io"
+            ]
+          }
+        ]
+      },
+      {
+        "ruleId": "rule2",
+        "priority": 2,
+        "clauses": [
+          {
+            "attribute": "email",
+            "op": "ends_with",
+            "values": [
+              "@somethingelse.com"
+            ]
+          }
+        ]
+      }
+    ],
+    "version": 2
+  },
+  {
+    "environment": "Production",
+    "excluded": [],
+    "identifier": "and-segment",
+    "included": [],
+    "name": "is_a_harness_developer_test_AND",
+    "rules": [],
+
+    "servingRules": [
+      {
+        "ruleId": "rule1",
+        "priority": 1,
+        "clauses": [
+          {
+            "attribute": "email",
+            "op": "ends_with",
+            "values": [
+              "@harness.io"
+            ]
+          },
+          {
+            "attribute": "role",
+            "op": "equal",
+            "values": [
+              "developer"
+            ]
+          }
+        ]
+      }
+    ],
+    "version": 2
+  }
+]

--- a/test/ff/ruby/server/sdk/sdk_test.rb
+++ b/test/ff/ruby/server/sdk/sdk_test.rb
@@ -301,7 +301,7 @@ class Ff::Ruby::Server::SdkTest < Minitest::Test
 
     processor.start
 
-    sleep(2)
+    sleep(3)
 
     assert_equal(1, callback.on_poller_ready_count)
     assert_equal(0, callback.on_poller_error_count)


### PR DESCRIPTION
[FFM-11241] - Target v2: Adding support for AND/OR in clauses

**What**
Adding support for processing the new `GroupServingRule` in `Segment`. Also update API definition for OpenAPIGenerator plugin. The default behaviour now is to check for the existence of `GroupServingRule` if found then we ignore the old `Rules` section. Old `Rules` section will continue to work to aid transition if `GroupServingRule` is not yet populated. Each entry in `GroupServingRule` is ORed while each list of clauses is ANDed. The `GroupServingRule` with the highest priority used first to allow reordering on the backend.

**Why**
This give the customer more flexibility on how they configure their rules in the backend.

**Testing**
Initial unit tests for now + testgrid later

[FFM-11241]: https://harness.atlassian.net/browse/FFM-11241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ