### PR TITLE
[FFM-11365] - Add new query parameter to target-segments

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -87,6 +87,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -127,6 +128,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -950,6 +952,17 @@ components:
       in: query
       required: false
       description: Unique identifier for the cluster for the account
+      schema:
+        type: string
+    segmentRulesV2QueryParam:
+      name: rules
+      in: query
+      required: false
+      description: >-
+        When set to rules=v2 will return AND rule compatible serving_rules
+        field. When not set or set to any other value will return old rules
+        field only compatible with OR rules.
+      allowEmptyValue: true
       schema:
         type: string
     environmentPathParam:

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -74,11 +74,10 @@ class HarnessConnector < Connector
   def get_segments
 
     begin
-
       return @api.get_all_segments(
 
         environment_uuid = @environment,
-        opts = get_query_params
+        opts = get_segment_query_params
       )
 
     rescue OpenapiClient::ApiError => e
@@ -104,7 +103,7 @@ class HarnessConnector < Connector
 
       identifier = identifier,
       environment_uuid = @environment,
-      opts = get_query_params
+      opts = get_segment_query_params
     )
   end
 
@@ -243,6 +242,16 @@ class HarnessConnector < Connector
       :'query_params' => {
 
         :'cluster' => @cluster
+      }
+    }
+  end
+
+  def get_segment_query_params
+    {
+      :'query_params' => {
+
+        :'cluster' => @cluster,
+        :'rules' => 'v2'
       }
     }
   end

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -105,7 +105,7 @@ class MetricsProcessorTest < Minitest::Test
     logger = Logger.new(STDOUT)
     callback = TestCallback.new
     connector = TestConnector.new
-    config = MiniTest::Mock.new
+    config = Minitest::Mock.new
     config.expect :kind_of?, true, [Config.class]
     config.expect :metrics_service_acceptable_duration, 10000
 
@@ -214,7 +214,7 @@ class MetricsProcessorTest < Minitest::Test
     logger = Logger.new(STDOUT)
     callback = TestCallback.new
     connector = TestConnector.new
-    config = MiniTest::Mock.new
+    config = Minitest::Mock.new
     config.expect :kind_of?, true, [Config.class]
     config.expect :metrics_service_acceptable_duration, 10000
 


### PR DESCRIPTION
**What**
Adds a new query parameter to tell the BE which rule JSON format the SDK is capable of handling locally

**Why**
Caching can be performed on the BE by keying on the URL

**Testing**
Manual + proxy