### PR TITLE
FFM-11211 Metrics enhancements

### DIFF
--- a/lib/ff/ruby/server/sdk/api/config.rb
+++ b/lib/ff/ruby/server/sdk/api/config.rb
@@ -35,7 +35,7 @@ class Config
 
     @frequency = @@min_frequency
 
-    @buffer_size = 2048
+    @buffer_size = 10000
 
     @all_attributes_private = false
 

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -120,7 +120,7 @@ class MetricsProcessor < Closeable
     if @evaluation_metrics.size > @max_buffer_size
       unless @evaluation_warning_issued.true?
         SdkCodes.warn_metrics_evaluations_max_size_exceeded(@config.logger)
-        @evaluation_warning_issued.set(true)
+        @evaluation_warning_issued.make_true
       end
       return
     end
@@ -133,7 +133,7 @@ class MetricsProcessor < Closeable
     if @target_metrics.size > @max_targets_buffer_size
       unless @target_warning_issued.true?
         SdkCodes.warn_metrics_targets_max_size_exceeded(@config.logger)
-        @target_warning_issued.set(true)
+        @target_warning_issued.make_true
       end
       return
     end
@@ -168,8 +168,8 @@ class MetricsProcessor < Closeable
 
     target_metrics_map.clear
 
-    @evaluation_warning_issued.set(false)
-    @target_warning_issued.set(false)
+    @evaluation_warning_issued.make_false
+    @target_warning_issued.make_false
 
     metrics = prepare_summary_metrics_body(evaluation_metrics_map_clone, target_metrics_map_clone)
 

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -222,8 +222,7 @@ class MetricsProcessor < Closeable
           @initialized = true
           SdkCodes::info_metrics_thread_started @config.logger
         end
-        sleep(5)
-        # sleep(@config.frequency)
+        sleep(@config.frequency)
         run_one_iteration
       end
     end

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -162,16 +162,11 @@ class MetricsProcessor < Closeable
       return
     end
 
-    already_seen = @seen_targets.compute_if_absent(target.identifier) do
-      false
-    end
+    already_seen = @seen_targets.put_if_absent(target.identifier, true)
 
     if already_seen
-      @config.logger.debug "Skipping target: #{target.identifier}, already seen or is private"
       return
     end
-
-    @seen_targets[target.identifier] = true
 
     attributes = target.attributes
     attributes.each do |k, v|

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -64,7 +64,7 @@ class MetricsProcessor < Closeable
     #                                             targets as a summary
     @global_target =  Target.new("RubySDK1", identifier=@global_target_identifier, name=@global_target_name)
     @ready = false
-    @jar_version = ""
+    @jar_version = Ff::Ruby::Server::Sdk::VERSION
     @server = "server"
     @sdk_version = "SDK_VERSION"
     @sdk_language = "SDK_LANGUAGE"
@@ -132,7 +132,7 @@ class MetricsProcessor < Closeable
   def run_one_iteration
     send_data_and_reset_cache(@evaluation_metrics.drain_to_map, @target_metrics)
 
-    @config.logger.debug "metrics: frequency map size #{@evaluation_metrics.size}. global target size #{@seen_targets.size}"
+    @config.logger.debug "metrics: frequency map size #{@evaluation_metrics.size}. targets map size #{@target_metrics.size} global target size #{@seen_targets.size}"
   end
 
   def send_data_and_reset_cache(evaluation_metrics_map, target_metrics_map)

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -104,6 +104,7 @@ class MetricsProcessor < Closeable
   def register_evaluation(target, feature_config, variation)
     if @evaluation_metrics.size > @max_buffer_size
       SdkCodes.warn_metrics_evaluations_max_size_exceeded(@config.logger)
+      return 
     end
 
     event = MetricsEvent.new(feature_config, @global_target, variation)

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -102,13 +102,8 @@ class MetricsProcessor < Closeable
   end
 
   def register_evaluation(target, feature_config, variation)
-
-    # TODO - don't flush metrics, only drain them here. We can't tie network requests to evaluations.
     if @evaluation_metrics.size > @max_buffer_size
-      @config.logger.warn "metrics buffer is full #{@evaluation_metrics.size} - flushing metrics"
-      @executor.post do
-        run_one_iteration
-      end
+      SdkCodes.warn_metrics_evaluations_max_size_exceeded(@config.logger)
     end
 
     event = MetricsEvent.new(feature_config, @global_target, variation)

--- a/lib/ff/ruby/server/sdk/common/sdk_codes.rb
+++ b/lib/ff/ruby/server/sdk/common/sdk_codes.rb
@@ -34,6 +34,13 @@ class SdkCodes
     logger.info SdkCodes.sdk_err_msg(7000)
   end
 
+  def self.warn_metrics_targets_max_size_exceeded(logger)
+    logger.warn SdkCodes.sdk_err_msg(7004)
+  end
+
+  def self.warn_metrics_evaluations_max_size_exceeded(logger)
+    logger.warn SdkCodes.sdk_err_msg(7007)
+  end
   def self.warn_auth_failed_srv_defaults(logger)
     logger.warn SdkCodes.sdk_err_msg(2001)
   end

--- a/lib/ff/ruby/server/sdk/common/sdk_codes.rb
+++ b/lib/ff/ruby/server/sdk/common/sdk_codes.rb
@@ -89,6 +89,8 @@ class SdkCodes
       7000 => "Metrics thread started",
       7001 => "Metrics thread exited",
       7002 => "Posting metrics failed, reason:",
+      7004 => "Target metrics exceeded max size, remaining targets for this analytics interval will not be sent",
+      7007 => "Evaluation metrics exceeded max size, remaining evaluations for this analytics interval will not be sent"
     }
 
   def self.sdk_err_msg(error_code, append_text = "")


### PR DESCRIPTION
# What
- Splits evaluation and target metrics into their own caches:
    - So that evaluations can be keyed on `flag + variation` and that we can track target metrics separately because we use the `global target` for evaluations 

- Implement seen targets - this was previously implemented but not working:
    - ensures that the metrics service only gets sent target metrics for a target once, for the lifetime of the SDK instance
    - ensures that the SDK processes truly unique targets fairly, and that old targets don't occupy the 100K limit set per 

- No longer flushes metrics if map is full, but instead logs a warning and returns. 

# Testing
- Metrics accuracy:
    - TestGrid metrics tests
    - Manual sample app
    - Non-anonymous targets appear in UI
    - Anonymous targets don't appear in UI
- SeenTargets:
    - Manual testing
- Evaluation limits
    - Manual 
