### PR TITLE
FFM-11657 Sort serving rules and flag rules in cache code

### DIFF
--- a/lib/ff/ruby/server/sdk/api/evaluator.rb
+++ b/lib/ff/ruby/server/sdk/api/evaluator.rb
@@ -311,7 +311,6 @@ class Evaluator < Evaluation
         if new_serving_rules != nil && !new_serving_rules.empty?
           # Use enhanced rules first if they're available
 
-          new_serving_rules.sort_by!(&:priority)
           new_serving_rules.each do |serving_rule|
             if evaluate_clauses_v2(serving_rule.clauses, target)
               return true
@@ -339,11 +338,7 @@ class Evaluator < Evaluation
       return nil
     end
 
-    sorted = serving_rules.sort do |a, b|
-      b.priority <=> a.priority
-    end
-
-    sorted.each do |rule|
+    serving_rules.each do |rule|
       next unless evaluate_rule(rule, target)
 
       if rule.serve.distribution != nil

--- a/lib/ff/ruby/server/sdk/api/storage_repository.rb
+++ b/lib/ff/ruby/server/sdk/api/storage_repository.rb
@@ -107,6 +107,7 @@ class StorageRepository < Repository
       return
     end
 
+    sort_flag_rules(feature_config)
     flag_key = format_flag_key(identifier)
 
     if @store != nil
@@ -141,6 +142,7 @@ class StorageRepository < Repository
       return
     end
 
+    sort_segment_serving_rules(segment)
     segment_key = format_segment_key(identifier)
 
     if @store != nil
@@ -238,6 +240,18 @@ class StorageRepository < Repository
     end
 
     false
+  end
+
+  def sort_flag_rules(flag)
+    if flag.rules && flag.rules.length > 1
+      flag.rules.sort_by!(&:priority)
+    end
+  end
+
+  def sort_segment_serving_rules(segment)
+    if segment.serving_rules && segment.serving_rules.length > 1
+      segment.serving_rules.sort_by!(&:priority)
+    end
   end
 
   def is_segment_outdated(identifier, new_segment)

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.3.0"
+        VERSION = "1.3.1"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.3.0"
+export ff_ruby_sdk_version="1.3.1"


### PR DESCRIPTION
# What
- Move the group `AND/OR` rules, and Flag `Rules`  outside of the critical evaluation path into the point we save them to the cache.

# Why
Avoid the cost of sorting multiple times during evaluations when it is unnecessary, which can add evaluation latency.

# Testing
TestGrid - both old style and new style scenarios pass.