### PR TITLE
move rake, minitest, standard to dev dependencies

### DIFF
--- a/ff-ruby-server-sdk.gemspec
+++ b/ff-ruby-server-sdk.gemspec
@@ -44,9 +44,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.require_paths += ["lib/ff/ruby/server/generated/lib"]
 
-  spec.add_dependency "rake", "~> 13.0"
-  spec.add_dependency "minitest", "~> 5.0"
-  spec.add_dependency "standard", "~> 1.3"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "standard", "~> 1.3"
 
   spec.add_dependency "rufus-scheduler", "~> 3.8"
   spec.add_dependency "libcache", "0.4.2"


### PR DESCRIPTION
These dependencies are needed for development and/or at build time, but to the best of my knowledge, not to run the built gem. As such, to trim down dependencies in projects that install `ff-ruby-server-sdk`, I believe these three should be moved to dev dependencies.

Let me know if I need to update something else, this was done rather hastily. 