### PR TITLE
FFM-12088 Retry on HTTP status code 0

### DIFF
--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -24,6 +24,50 @@ client.init(apiKey, ConfigBuilder
 | enableStream    | analytics_enabled(false)                           | Enable streaming mode.                                                                                                                           | true                                 |
 | enableAnalytics | stream_enabled(true)                               | Enable analytics.  Metrics data is posted every 60s                                                                                              | true                                 |
 
+## Client Initialization Options
+The Harness Feature Flags SDK for Ruby provides flexible initialization strategies to accommodate various application requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK.
+
+### Asynchronous (Non-Blocking) Initialization
+The SDK can be initialized asynchronously without blocking the main thread or requiring a callback. In this case, defaults will be served until the SDK completes the initialization process.
+
+```ruby
+client = CfClient.instance
+client.init(api_key, config)
+
+# Will serve default until the SDK completes initialization
+result = client.bool_variation("bool_flag", target, false)
+```
+
+### Synchronous (Blocking) Initialization
+
+In cases where it's critical to ensure the SDK is initialized before evaluating flags, the SDK offers a synchronous initialization method. This approach blocks the current thread until the SDK is fully initialized or the optional specified timeout period elapses.
+
+The synchronous method is useful for environments where feature flag decisions are needed before continuing, such as during application startup.
+
+You can use the `wait_for_initialization` method, optionally providing a timeout to prevent waiting indefinitely in case of unrecoverable isues, e.g. incorrect API key used.
+
+**Usage with a timeout**
+
+```ruby
+client = CfClient.instance
+client.init(api_key, config)
+
+client.wait_for_initialization
+
+result = client.bool_variation("bool_flag", target, false)
+```
+
+**Usage without a timeout**
+
+```ruby
+client = CfClient.instance
+client.init(api_key, config)
+
+client.wait_for_initialization(timeout: 3000)
+
+result = client.bool_variation("bool_flag", target, false)
+```
+
 ## Logging Configuration
 You can provide your own logger to the SDK i.e. using the moneta logger we can do this
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -40,11 +40,11 @@ result = client.bool_variation("bool_flag", target, false)
 
 ### Synchronous (Blocking) Initialization
 
-In cases where it's critical to ensure the SDK is initialized before evaluating flags, the SDK offers a synchronous initialization method. This approach blocks the current thread until the SDK is fully initialized or the optional specified timeout period elapses.
+In cases where it's critical to ensure the SDK is initialized before evaluating flags, the SDK offers a synchronous initialization method. This approach blocks the current thread until the SDK is fully initialized or the optional specified timeout (in milliseconds) period elapses.
 
 The synchronous method is useful for environments where feature flag decisions are needed before continuing, such as during application startup.
 
-You can use the `wait_for_initialization` method, optionally providing a timeout to prevent waiting indefinitely in case of unrecoverable isues, e.g. incorrect API key used.
+You can use the `wait_for_initialization` method, optionally providing a timeout in milliseconds to prevent waiting indefinitely in case of unrecoverable isues, e.g. incorrect API key used.
 
 **Usage with a timeout**
 
@@ -63,7 +63,7 @@ result = client.bool_variation("bool_flag", target, false)
 client = CfClient.instance
 client.init(api_key, config)
 
-client.wait_for_initialization(timeout: 3000)
+client.wait_for_initialization(timeout_ms: 3000)
 
 result = client.bool_variation("bool_flag", target, false)
 ```

--- a/lib/ff/ruby/server/sdk/api/auth_service.rb
+++ b/lib/ff/ruby/server/sdk/api/auth_service.rb
@@ -89,8 +89,9 @@ class AuthService < Closeable
     # 503 service unavailable
     # 504 gateway timeout
     #  -1 OpenAPI error (timeout etc)
+    # 0 Un-categorised typhoeus error
     case code
-    when 408,425,429,500,502,503,504,-1
+    when 408,425,429,500,502,503,504,-1, 0
       return true
     else
       return false

--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -50,11 +50,9 @@ class CfClient < Closeable
     end
   end
 
-  def wait_for_initialization
-
+  def wait_for_initialization(timeout: nil)
     if @client != nil
-
-      @client.wait_for_initialization
+      @client.wait_for_initialization(timeout: timeout)
     end
   end
 

--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -50,9 +50,9 @@ class CfClient < Closeable
     end
   end
 
-  def wait_for_initialization(timeout: nil)
+  def wait_for_initialization(timeout_ms: nil)
     if @client != nil
-      @client.wait_for_initialization(timeout: timeout)
+      @client.wait_for_initialization(timeout: timeout_ms)
     end
   end
 

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -241,7 +241,7 @@ class InnerClient < ClientCallback
         # Check if a timeout is specified and has been exceeded
         if timeout && (Time.now - start_time) > (timeout / 1000.0)
           # raise "Initialization timed out after #{timeout} seconds"
-          @config.logger.error ""
+          @config.logger.warn "The SDK has timed out waiting to initialize with supplied timeout #{timeout} ms"
           handle_initialization_failure
         end
 

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -240,7 +240,6 @@ class InnerClient < ClientCallback
       until @initialized
         # Check if a timeout is specified and has been exceeded
         if timeout && (Time.now - start_time) > (timeout / 1000.0)
-          # raise "Initialization timed out after #{timeout} seconds"
           @config.logger.warn "The SDK has timed out waiting to initialize with supplied timeout #{timeout} ms"
           handle_initialization_failure
         end

--- a/lib/ff/ruby/server/sdk/common/sdk_codes.rb
+++ b/lib/ff/ruby/server/sdk/common/sdk_codes.rb
@@ -14,6 +14,17 @@ class SdkCodes
     logger.info SdkCodes.sdk_err_msg(1000)
   end
 
+  def self.info_sdk_waiting_to_initialize(logger, timeout)
+    if timeout
+      message = "with timeout: #{timeout} ms"
+    else
+
+      message = "with no timeout"
+
+    end
+    logger.info SdkCodes.sdk_err_msg(1003, message)
+  end
+
   def self.info_sdk_auth_ok(logger)
     logger.info SdkCodes.sdk_err_msg(2000)
   end
@@ -76,6 +87,7 @@ class SdkCodes
       1000 => "The SDK has successfully initialized",
       1001 => "The SDK has failed to initialize due to the following authentication error:",
       1002 => "The SDK has failed to initialize due to a missing or empty API key",
+      1003 => "The SDK is waiting for initialzation to complete",
       # SDK_AUTH_2xxx
       2000 => "Authenticated ok",
       2001 => "Authentication failed with a non-recoverable error - defaults will be served",

--- a/lib/ff/ruby/server/sdk/connector/harness_connector.rb
+++ b/lib/ff/ruby/server/sdk/connector/harness_connector.rb
@@ -46,6 +46,11 @@ class HarnessConnector < Connector
         # determine if a timeout has occurred. This is fixed in 6.3.0 but requires Ruby version to be increased to 2.7
         # https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0
         @config.logger.warn "OpenapiClient::ApiError [\n\n#{e}\n]"
+
+        if e.code
+          return e.code
+        end
+
         return -1
       end
 

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.3.2"
+        VERSION = "1.3.3"
       end
     end
   end

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.3.3"
+        VERSION = "1.4.0"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.3.3"
+export ff_ruby_sdk_version="1.4.0"

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.3.2"
+export ff_ruby_sdk_version="1.3.3"


### PR DESCRIPTION
# What
- Http code 0 is returned by the typheous client for any uncategorised http errors.  We should be able to assume most of the uncategorised attempts to connect to SaaS / Proxy are transient, and allow the SDK to retry. This PR adds `0` to the list of retryable codes.

- `-1` was being returned due to a bug in the OpenAPi generator, which meant the retryable codes were not being properly evaluated.  This returns the code if it exists, or -1 if not  

- Adds an optional `timeout_ms` parameter to `wait_for_initialized`

# Testing 
Used local proxy tool to
- return `0` for auth attempts. SDK retries
- return `404` for auth attempts, SDk does not retry
- supply `timeout_ms` argument and delay auth, the `wait_for_initialization` call unblocks and the SDK serves defaults