### PR TITLE
FFM-12192 Add guards for invalid Metrics 

### DIFF
--- a/lib/ff/ruby/server/sdk/api/inner_client_flag_evaluate_callback.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client_flag_evaluate_callback.rb
@@ -23,7 +23,7 @@ class InnerClientFlagEvaluateCallback < FlagEvaluateCallback
 
   def process_evaluation(feature_config, target, variation)
 
-    @logger.debug "Processing evaluation: " + feature_config.feature.to_s + ", " + target.identifier.to_s
+    @logger.debug "Processing evaluation: #{feature_config&.feature || 'nil feature'}, #{target&.identifier || 'nil target'}"
 
     @metrics_processor.register_evaluation(target, feature_config, variation)
   end

--- a/lib/ff/ruby/server/sdk/api/metrics_event.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_event.rb
@@ -2,11 +2,12 @@ class MetricsEvent
 
   attr_accessor :feature_config, :target, :variation
 
-  def initialize(feature_config, target, variation)
+  def initialize(feature_config, target, variation, logger)
 
     @target = target
     @variation = variation
     @feature_config = feature_config
+    @logger = logger
     freeze
   end
 

--- a/lib/ff/ruby/server/sdk/api/metrics_event.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_event.rb
@@ -16,6 +16,10 @@ class MetricsEvent
   end
 
   def eql?(other)
+    # Guard clause other is the same type.
+    # While it should be, this adds protection for an edge case we are seeing with very large
+    # project sizes. Issue being tracked in FFM-12192, and once resolved, can feasibly remove
+    # these checks in a future release.
     unless other.is_a?(MetricsEvent)
       @logger.warn("Warning: Attempted to compare MetricsEvent with #{other.class.name}" )
       return false

--- a/lib/ff/ruby/server/sdk/api/metrics_event.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_event.rb
@@ -15,6 +15,11 @@ class MetricsEvent
   end
 
   def eql?(other)
+    unless other.is_a?(MetricsEvent)
+      @logger.warn("Warning: Attempted to compare MetricsEvent with #{other.class.name}" )
+      return false
+    end
+
     feature_config.feature == other.feature_config.feature and
       variation.identifier == other.variation.identifier and
       target.identifier == other.target.identifier

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -29,6 +29,7 @@ class MetricsProcessor < Closeable
       self[key]
     end
 
+    # TODO Will be removed in V2 in favour of simplified clearing. Currently not used outside of tests.
     def drain_to_map
       result = {}
       each_key do |key|
@@ -158,8 +159,14 @@ class MetricsProcessor < Closeable
   end
 
   def send_data_and_reset_cache(evaluation_metrics_map, target_metrics_map)
-    evaluation_metrics_map_clone = evaluation_metrics_map.drain_to_map
+    # Clone and clear evaluation metrics map
+    evaluation_metrics_map_clone = Concurrent::Map.new
 
+    evaluation_metrics_map.each_pair do |key, value|
+      evaluation_metrics_map_clone[key] = value
+    end
+
+    evaluation_metrics_map.clear
     target_metrics_map_clone = Concurrent::Map.new
 
     target_metrics_map.each_pair do |key, value|

--- a/lib/ff/ruby/server/sdk/version.rb
+++ b/lib/ff/ruby/server/sdk/version.rb
@@ -5,7 +5,7 @@ module Ff
     module Server
       module Sdk
 
-        VERSION = "1.4.0"
+        VERSION = "1.4.1"
       end
     end
   end

--- a/scripts/sdk_specs.sh
+++ b/scripts/sdk_specs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export ff_ruby_sdk="ff-ruby-server-sdk"
-export ff_ruby_sdk_version="1.4.0"
+export ff_ruby_sdk_version="1.4.1"

--- a/test/ff/ruby/server/sdk/cf_client_test.rb
+++ b/test/ff/ruby/server/sdk/cf_client_test.rb
@@ -37,7 +37,7 @@ class CfClientTest < Minitest::Test
                                             .event_url("http://localhost:#{port}/api/1.0")
                                             .config_url("http://localhost:#{port}/api/1.0").build)
 
-      client.wait_for_initialization
+      client.wait_for_initialization(timeout_ms: 5000)
 
       target = Target.new("RubyTestSDK", identifier="rubytestsdk", attributes={"location": "emea"})
 

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -198,15 +198,22 @@ class MetricsProcessorTest < Minitest::Test
 
   def test_comparable_metrics_event_equals_and_hash
 
-    event1 = MetricsEvent.new(@feature1, @target, @variation1)
-    event2 = MetricsEvent.new(@feature1, @target, @variation1)
+    event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))
+    event2 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))
 
     assert(event1 == event2)
 
-    event1 = MetricsEvent.new(@feature1, @target, @variation1)
-    event2 = MetricsEvent.new(@feature2, @target, @variation2)
+    event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))
+    event2 = MetricsEvent.new(@feature2, @target, @variation2, Logger.new(STDOUT))
 
     assert(event1 != event2)
+  end
+
+  def test_metrics_event_eql_with_invalid_object
+    event = MetricsEvent.new(@feature1, @target, @variation1,Logger.new(STDOUT))
+    non_event = "Not a MetricsEvent"
+
+    refute_equal(event, non_event, "MetricsEvent should not be equal to a non-MetricsEvent object")
   end
 
   def test_flush_map_when_buffer_fills


### PR DESCRIPTION
# What
We are seeing an edge case (see JIRA FFM-12192) where in very large project sizes the arguments passed to metrics functions can be invalid.  We are still to root cause this, so this PR checks for invalid metrics data and skips them if detected. 

# Testing
New unit tests
Manual testing with valid and invalid inputs
Testgrid integration suite