### PR TITLE
FFM-12192 Use client Singleton / Lock eval & target map clone operation

### DIFF
--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -1,56 +1,23 @@
-
+require 'singleton'
 require_relative "../../generated/lib/openapi_client"
 require_relative "../common/closeable"
 require_relative "inner_client"
 
 class CfClient < Closeable
+  include Singleton
 
-  # Static:
-  class << self
-
-    @@instance = CfClient.new
-
-    def instance
-
-      @@instance
+  def init(api_key, config, connector = nil)
+    # Only initialize if @client is nil to avoid reinitialization
+    unless @client
+      @config = config || ConfigBuilder.new.build
+      @client = InnerClient.new(api_key, @config, connector)
+      @config.logger.debug "Client initialized with API key: #{api_key}"
     end
+    @client
   end
 
-  # Static - End
 
-  def initialize(api_key = nil, config = nil, connector = nil)
-
-    if config == nil
-
-      @config = ConfigBuilder.new.build
-    else
-
-      @config = config
-    end
-
-    @client = InnerClient.new(api_key, config, connector)
-
-    @config.logger.debug "Client (1): " + @client.to_s
-  end
-
-  def init(api_key = nil, config = nil, connector = nil)
-
-    if @client == nil
-
-      @config = config
-
-      @client = InnerClient.new(
-
-        api_key = api_key,
-        config = config,
-        connector = connector
-      )
-
-      @config.logger.debug "Client (2): " + @client.to_s
-    end
-  end
-
-  def wait_for_initialization(timeout_ms: nil)
+def wait_for_initialization(timeout_ms: nil)
     if @client != nil
       @client.wait_for_initialization(timeout: timeout_ms)
     end


### PR DESCRIPTION
# What
- We are seeing segment faults that are closely linked to the evaluation metrics map.  
- Customer shared logs to confirm the evaluation metrics map has stored corrupt data. 

# Theory
Theory is when we clone the evaluation metrics map, the evaluation thread can and will modify the original map concurrently, resulting in data corruption.  Theory extends to the Segment fault being caused by this access too.

Also, the cf_client uses a class variable which is not thread safe, which could be causing issues.

# Fix  
Lock the cloning operation with a mutex
Replace the client class variable with a Singleton

# Testing
- Unit tests for singleton access 
- Testgrid 