### PR TITLE
FFM-12192 Patch Four: Replace ConcurrentMap 

### DIFF
--- a/lib/ff/ruby/server/sdk/api/metrics_event.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_event.rb
@@ -35,4 +35,15 @@ class MetricsEvent
   end
 
 
+  # Exclude logger from serialization
+  def marshal_dump
+    [@feature_config, @target, @variation]
+  end
+
+  def marshal_load(array)
+    @feature_config, @target, @variation = array
+    @logger = nil  # Reinitialize logger if needed
+  end
+
+
 end

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -136,6 +136,8 @@ class MetricsProcessor < Closeable
   def send_data_and_reset_cache(evaluation_metrics_map, target_metrics_map)
 
     @send_data_mutex.synchronize do
+      begin
+
 
       evaluation_metrics_map_clone, target_metrics_map_clone = @metric_maps_mutex.synchronize do
         # Deep clone the evaluation metrics
@@ -158,6 +160,9 @@ class MetricsProcessor < Closeable
         if end_time - start_time > @config.metrics_service_acceptable_duration
           @config.logger.debug "Metrics service API duration=[" + (end_time - start_time).to_s + "]"
         end
+      end
+      rescue => e
+        @config.logger.warn "Error when preparing and sending metrics: #{e.message}"
       end
     end
   end

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -147,7 +147,7 @@ class MetricsProcessor < Closeable
           @config.logger.debug "No metrics to send. Skipping sending metrics this interval"
           return
         end
-        
+
         # Deep clone the evaluation metrics
         cloned_evaluations = Marshal.load(Marshal.dump(evaluation_metrics_map)).freeze
         evaluation_metrics_map.clear

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -142,6 +142,12 @@ class MetricsProcessor < Closeable
 
 
       evaluation_metrics_map_clone, target_metrics_map_clone = @metric_maps_mutex.synchronize do
+        # Check if both cloned maps are empty; if so, skip sending metrics
+        if evaluation_metrics_map.empty? && target_metrics_map.empty?
+          @config.logger.debug "No metrics to send. Skipping sending metrics this interval"
+          return
+        end
+        
         # Deep clone the evaluation metrics
         cloned_evaluations = Marshal.load(Marshal.dump(evaluation_metrics_map)).freeze
         evaluation_metrics_map.clear

--- a/lib/ff/ruby/server/sdk/api/metrics_processor.rb
+++ b/lib/ff/ruby/server/sdk/api/metrics_processor.rb
@@ -139,11 +139,11 @@ class MetricsProcessor < Closeable
 
       evaluation_metrics_map_clone, target_metrics_map_clone = @metric_maps_mutex.synchronize do
         # Deep clone the evaluation metrics
-        cloned_evaluations = Marshal.load(Marshal.dump(evaluation_metrics_map))
+        cloned_evaluations = Marshal.load(Marshal.dump(evaluation_metrics_map)).freeze
         evaluation_metrics_map.clear
 
         # Deep clone the target metrics
-        cloned_targets = Marshal.load(Marshal.dump(target_metrics_map))
+        cloned_targets = Marshal.load(Marshal.dump(target_metrics_map)).freeze
         target_metrics_map.clear
         [cloned_evaluations, cloned_targets]
 

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -1,6 +1,5 @@
 require "minitest/autorun"
 require "ff/ruby/server/sdk"
-require "concurrent/atomics"
 
 class MetricsProcessorTest < Minitest::Test
 

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -142,6 +142,66 @@ class MetricsProcessorTest < Minitest::Test
     assert_target_data connector.get_captured_metrics[0].target_data
   end
 
+  def test_multiple_threads_calling_send_data_and_reset_cache
+    logger = Logger.new(STDOUT)
+    callback = TestCallback.new
+    connector = TestConnector.new
+    config = Minitest::Mock.new
+    config.expect :kind_of?, true, [Config]
+    config.expect :metrics_service_acceptable_duration, 10000
+    def config.logger
+      @logger ||= Logger.new(STDOUT)
+    end
+    metrics_processor = MetricsProcessor.new
+    metrics_processor.init(connector, config, callback)
+
+    callback.wait_until_ready
+
+    # Register evaluations
+    (1..10).each do |i|
+      feature = OpenapiClient::FeatureConfig.new
+      feature.feature = "feature-#{i}"
+      variation = OpenapiClient::Variation.new
+      variation.identifier = "variation-#{i}"
+      variation.value = "value-#{i}"
+      variation.name = "Test-#{i}"
+
+      variation2 = OpenapiClient::Variation.new
+      variation2.identifier = "variation2-#{i}"
+      variation2.value = "value2-#{i}"
+      variation2.name = "Test2-#{i}"
+      feature.variations = [variation, @variation2]
+      metrics_processor.register_evaluation(@target, feature, variation)
+    end
+
+    # Define a method to call send_data_and_reset_cache
+    send_metrics = Proc.new do
+      metrics_processor.send(:send_data_and_reset_cache, metrics_processor.send(:get_frequency_map), metrics_processor.instance_variable_get(:@target_metrics))
+    end
+
+    # Spawn multiple threads to call send_data_and_reset_cache concurrently
+    threads = []
+    5.times do
+      threads << Thread.new { send_metrics.call }
+    end
+
+    # Wait for all threads to complete
+    threads.each(&:join)
+
+    # Verify that post_metrics was called exactly once
+    assert_equal 1, connector.get_captured_metrics.size, "post_metrics should be called only once despite multiple concurrent calls"
+
+    # Verify that metrics_data contains all registered metrics
+    metrics_data = connector.get_captured_metrics[0].metrics_data
+    assert_equal 10, metrics_data.size, "All 10 metrics should be sent"
+
+    # Verify that target_data contains the global target
+    assert_equal 1, connector.get_captured_metrics[0].target_data.size, "There should be one target data entry"
+    target_data = connector.get_captured_metrics[0].target_data.first
+    assert_equal @target.identifier, target_data.identifier, "Target should be included in target metrics"
+  end
+
+
   def assert_target_data(target_data)
     targets = {}
 

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -158,7 +158,7 @@ class MetricsProcessorTest < Minitest::Test
 
     assert targets.key?("target-id")
   end
-  
+
   def test_comparable_metrics_event_equals_and_hash
 
     event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))

--- a/test/ff/ruby/server/sdk/metrics_processor_test.rb
+++ b/test/ff/ruby/server/sdk/metrics_processor_test.rb
@@ -158,43 +158,7 @@ class MetricsProcessorTest < Minitest::Test
 
     assert targets.key?("target-id")
   end
-
-  def test_frequency_map_increment
-
-    map = MetricsProcessor::FrequencyMap.new
-
-    event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))
-    event2 = MetricsEvent.new(@feature2, @target, @variation2, Logger.new(STDOUT))
-
-    map.increment event1
-    map.increment event2
-
-    map.increment event1
-    map.increment event2
-
-    assert_equal 2, map[event1]
-    assert_equal 2, map[event2]
-  end
-
-  def test_frequency_map_drain_to_map
-    map = MetricsProcessor::FrequencyMap.new
-
-    event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))
-    event2 = MetricsEvent.new(@feature2, @target, @variation2, Logger.new(STDOUT))
-
-    map.increment event1
-    map.increment event2
-
-    map.increment event1
-    map.increment event2
-
-    new_map = map.drain_to_map
-
-    assert_equal 0, map.size
-    assert_equal 2, new_map[event1]
-    assert_equal 2, new_map[event2]
-  end
-
+  
   def test_comparable_metrics_event_equals_and_hash
 
     event1 = MetricsEvent.new(@feature1, @target, @variation1, Logger.new(STDOUT))


### PR DESCRIPTION
# What
- Replaces `concurrent-ruby/ConcurrentMap` with mutexes to resolve a segmentation fault that is seen under difficult to reproduce circumstances.
- Uses a new mutex for when we aggregate and send data at the end an intervak
- Uses a `Set` for seen targets to improve performance 

# Testing
- New multi-threaded unit tests
- Testgrid
- Manual testing