### PR TITLE
feat: [FFM-12281]: thread safety fixes 

### DIFF
--- a/lib/ff/ruby/server/sdk/api/cf_client.rb
+++ b/lib/ff/ruby/server/sdk/api/cf_client.rb
@@ -5,13 +5,17 @@ require_relative "inner_client"
 
 class CfClient < Closeable
   include Singleton
-
+  
+  @@instance_mutex = Mutex.new
   def init(api_key, config, connector = nil)
     # Only initialize if @client is nil to avoid reinitialization
-    unless @client
-      @config = config || ConfigBuilder.new.build
-      @client = InnerClient.new(api_key, @config, connector)
-      @config.logger.debug "Client initialized with API key: #{api_key}"
+    
+    @@instance_mutex.synchronize do
+      unless @client
+        @config = config || ConfigBuilder.new.build
+        @client = InnerClient.new(api_key, @config, connector)
+        @config.logger.debug "Client initialized with API key: #{api_key}"
+      end
     end
     @client
   end

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -120,9 +120,11 @@ class InnerClient < ClientCallback
   end
 
   def on_auth_failed
-    SdkCodes::warn_auth_failed_srv_defaults @config.logger
-    @initialized = true
-    @condition.broadcast
+    @my_mutex.synchronize do
+      SdkCodes::warn_auth_failed_srv_defaults @config.logger
+      @initialized = true
+      @condition.broadcast
+    end
   end
 
   def close

--- a/lib/ff/ruby/server/sdk/api/inner_client.rb
+++ b/lib/ff/ruby/server/sdk/api/inner_client.rb
@@ -122,7 +122,7 @@ class InnerClient < ClientCallback
   def on_auth_failed
     SdkCodes::warn_auth_failed_srv_defaults @config.logger
     @initialized = true
-    @condition.signal
+    @condition.broadcast
   end
 
   def close
@@ -243,7 +243,7 @@ class InnerClient < ClientCallback
 
       SdkCodes.info_sdk_init_ok @config.logger
 
-      @condition.signal
+      @condition.broadcast
       @initialized = true
     end
   end
@@ -257,7 +257,6 @@ class InnerClient < ClientCallback
       remaining = timeout ? timeout / 1000.0 : nil # Convert timeout to seconds
 
       until @initialized
-
         # Break if timeout has elapsed
         if remaining && remaining <= 0
           @config.logger.warn "The SDK has timed out waiting to initialize with supplied timeout #{timeout} ms. The SDK will continue to initialize in the background.  Default variations will be served until the SDK initializes."


### PR DESCRIPTION
**Changes**

Ensure only one instance of `CfClient` can ever be created, protect against multithreaded edge cases where multiple instances could be created in a short period by controlling access with a mutex. 

Use `condition.broadcast` instead of `condition.signal` to ensure initialised signal is received by all listeners on every thread. 